### PR TITLE
Fix a false positive in REFCOUNT_FULL in recent 5.4.x

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -52,7 +52,7 @@ def add_kconfig_checks(l, arch):
              KconfigCheck('self_protection', 'defconfig', 'DEBUG_SET_MODULE_RONX', 'y'),
              modules_not_set)] # DEBUG_SET_MODULE_RONX was before v4.11
     l += [OR(KconfigCheck('self_protection', 'defconfig', 'REFCOUNT_FULL', 'y'),
-             VersionCheck((5, 5)))] # REFCOUNT_FULL is enabled by default since v5.5
+             VersionCheck((5, 4, 208)))] # REFCOUNT_FULL is enabled by default since v5.4.208
     if arch in ('X86_64', 'ARM64', 'X86_32'):
         l += [KconfigCheck('self_protection', 'defconfig', 'RANDOMIZE_BASE', 'y')]
     if arch in ('X86_64', 'ARM64', 'ARM'):

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -125,9 +125,12 @@ class SysctlCheck(OptCheck):
 
 class VersionCheck:
     def __init__(self, ver_expected):
-        assert(ver_expected and isinstance(ver_expected, tuple) and len(ver_expected) == 2), \
+        assert(ver_expected and isinstance(ver_expected, tuple) and 2 <= len(ver_expected) <= 3), \
                f'invalid version "{ver_expected}" for VersionCheck'
         self.ver_expected = ver_expected
+        self.ver_expected_print = f'{self.ver_expected[0]}.{self.ver_expected[1]}'
+        if len(ver_expected) == 3:
+            self.ver_expected_print += f'.{self.ver_expected[2]}'
         self.ver = ()
         self.result = None
 
@@ -137,18 +140,18 @@ class VersionCheck:
 
     def check(self):
         if self.ver[0] > self.ver_expected[0]:
-            self.result = f'OK: version >= {self.ver_expected[0]}.{self.ver_expected[1]}'
+            self.result = f'OK: version >= {self.ver_expected_print}'
             return
         if self.ver[0] < self.ver_expected[0]:
-            self.result = f'FAIL: version < {self.ver_expected[0]}.{self.ver_expected[1]}'
+            self.result = f'FAIL: version < {self.ver_expected_print}'
             return
         if self.ver[1] >= self.ver_expected[1]:
-            self.result = f'OK: version >= {self.ver_expected[0]}.{self.ver_expected[1]}'
+            self.result = f'OK: version >= {self.ver_expected_print}'
             return
-        self.result = f'FAIL: version < {self.ver_expected[0]}.{self.ver_expected[1]}'
+        self.result = f'FAIL: version < {self.ver_expected_print}'
 
     def table_print(self, _mode, with_results):
-        ver_req = f'kernel version >= {self.ver_expected[0]}.{self.ver_expected[1]}'
+        ver_req = f'kernel version >= {self.ver_expected_print}'
         print(f'{ver_req:<91}', end='')
         if with_results:
             print(f'| {colorize_result(self.result)}', end='')


### PR DESCRIPTION
Extend VersionCheck to be able to take a three-tuple, x.y.z kernel version in order to properly recognise 5.4.208 as when this became the default behavior and thus CONFIG_REFCOUNT_FULL disappeared.


Closes: https://github.com/a13xp0p0v/kernel-hardening-checker/issues/88