### PR TITLE
Don't fail some sysctl checks if a config option already takes care of it

### DIFF
--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -219,8 +219,8 @@ def parse_sysctl_file(mode, parsed_options, fname):
         sys.exit(f'[!] ERROR: {fname} doesn\'t look like a sysctl output file, please try `sudo sysctl -a > {fname}`')
 
     # let's check the presence of a sysctl option available for root
-    if 'net.core.bpf_jit_harden' not in parsed_options and mode != 'json':
-        print(f'[!] WARNING: sysctl option "net.core.bpf_jit_harden" available for root is not found in {fname}, please try `sudo sysctl -a > {fname}`')
+    if 'kernel.cad_pid' not in parsed_options and mode != 'json':
+        print(f'[!] WARNING: sysctl option "kernel.cad_pid" available for root is not found in {fname}, please try `sudo sysctl -a > {fname}`')
 
 
 def main():

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -673,7 +673,7 @@ def add_sysctl_checks(l, _arch):
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')] # with a custom patch, see https://lwn.net/Articles/696216/
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kexec_load_disabled', '1'),
-             AND(KconfigCheck('cut_attack_surfice', 'kspp', 'KEXEC_CORE', 'is not set'),
+             AND(KconfigCheck('-', '-', 'KEXEC_CORE', 'is not set'),
                  have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'user.max_user_namespaces', '0')] # may break the upower daemon in Ubuntu
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -663,14 +663,17 @@ def add_sysctl_checks(l, _arch):
 # Calling the SysctlCheck class constructor:
 #   SysctlCheck(reason, decision, name, expected)
 
+    # use an omnipresent config symbol to see if we have a config file
+    have_config_file = KconfigCheck('-', '-', 'DEFAULT_INIT', 'is present')
     l += [OR(SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'BPF_JIT', 'is not set'),
-                 # use an omnipresent config symbol to see if we have a config file to check BPF_JIT.
-                 KconfigCheck('cut_attack_surface', 'kspp', 'DEFAULT_INIT', 'is present')))]
+                 have_config_file))]
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')] # with a custom patch, see https://lwn.net/Articles/696216/
-    l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kexec_load_disabled', '1')]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kexec_load_disabled', '1'),
+             AND(KconfigCheck('cut_attack_surfice', 'kspp', 'KEXEC_CORE', 'is not set'),
+                 have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'user.max_user_namespaces', '0')] # may break the upower daemon in Ubuntu
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.unprivileged_bpf_disabled', '1')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -663,7 +663,10 @@ def add_sysctl_checks(l, _arch):
 # Calling the SysctlCheck class constructor:
 #   SysctlCheck(reason, decision, name, expected)
 
-    l += [SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2')]
+    l += [OR(SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2'),
+             AND(KconfigCheck('cut_attack_surface', 'kspp', 'BPF_JIT', 'is not set'),
+                 # use an omnipresent config symbol to see if we have a config file to check BPF_JIT.
+                 KconfigCheck('cut_attack_surface', 'kspp', 'DEFAULT_INIT', 'is present')))]
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')] # with a custom patch, see https://lwn.net/Articles/696216/

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -688,7 +688,9 @@ def add_sysctl_checks(l, _arch):
           # At first, it disabled unprivileged userfaultfd,
           # and since v5.11 it enables unprivileged userfaultfd for user-mode only.
 
-    l += [SysctlCheck('cut_attack_surface', 'clipos', 'kernel.modules_disabled', '1')] # radical, but may be useful in some cases
+    l += [OR(SysctlCheck('cut_attack_surface', 'clipos', 'kernel.modules_disabled', '1'), # radical, but may be useful in some cases
+             AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
+                 have_config_file))]
 
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.protected_symlinks', '1')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.protected_hardlinks', '1')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -681,8 +681,7 @@ def add_sysctl_checks(l, _arch):
              AND(KconfigCheck('cut_attack_surface', 'lockdown', 'BPF_SYSCALL', 'is not set'),
                  have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
-    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0'),
-             SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', 'is not set'))]
+    l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0'),
              AND(KconfigCheck('cut_attack_surface', 'grsec', 'USERFAULTFD', 'is not set'),
                  have_config_file))]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -667,7 +667,7 @@ def add_sysctl_checks(l, _arch):
     have_config_file = KconfigCheck('-', '-', 'LOCALVERSION', 'is present')
 
     l += [OR(SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2'),
-             AND(KconfigCheck('cut_attack_surface', 'kspp', 'BPF_JIT', 'is not set'),
+             AND(KconfigCheck('-', '-', 'BPF_JIT', 'is not set'),
                  have_config_file))]
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -682,7 +682,9 @@ def add_sysctl_checks(l, _arch):
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0'),
              SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', 'is not set'))]
-    l += [SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0')]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0'),
+             AND(KconfigCheck('cut_attack_surface', 'grsec', 'USERFAULTFD', 'is not set'),
+                 have_config_file))]
           # At first, it disabled unprivileged userfaultfd,
           # and since v5.11 it enables unprivileged userfaultfd for user-mode only.
 

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -680,7 +680,8 @@ def add_sysctl_checks(l, _arch):
              AND(KconfigCheck('cut_attack_surface', 'lockdown', 'BPF_SYSCALL', 'is not set'),
                  have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
-    l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0'),
+             SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', 'is not set'))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0')]
           # At first, it disabled unprivileged userfaultfd,
           # and since v5.11 it enables unprivileged userfaultfd for user-mode only.

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -676,7 +676,9 @@ def add_sysctl_checks(l, _arch):
                  have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'user.max_user_namespaces', '0')] # may break the upower daemon in Ubuntu
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]
-    l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.unprivileged_bpf_disabled', '1')]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.unprivileged_bpf_disabled', '1'),
+             AND(KconfigCheck('cut_attack_surface', 'lockdown', 'BPF_SYSCALL', 'is not set'),
+                 have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -664,33 +664,33 @@ def add_sysctl_checks(l, _arch):
 #   SysctlCheck(reason, decision, name, expected)
 
     # Use an omnipresent kconfig symbol to see if we have a kconfig file for checking
-    have_config_file = KconfigCheck('-', '-', 'LOCALVERSION', 'is present')
+    have_kconfig = KconfigCheck('-', '-', 'LOCALVERSION', 'is present')
 
     l += [OR(SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2'),
              AND(KconfigCheck('-', '-', 'BPF_JIT', 'is not set'),
-                 have_config_file))]
+                 have_kconfig))]
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')] # with a custom patch, see https://lwn.net/Articles/696216/
-    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kexec_load_disabled', '1'),
-             AND(KconfigCheck('-', '-', 'KEXEC_CORE', 'is not set'),
-                 have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'user.max_user_namespaces', '0')] # may break the upower daemon in Ubuntu
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]
-    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.unprivileged_bpf_disabled', '1'),
-             AND(KconfigCheck('cut_attack_surface', 'lockdown', 'BPF_SYSCALL', 'is not set'),
-                 have_config_file))]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kexec_load_disabled', '1'),
+             AND(KconfigCheck('-', '-', 'KEXEC_CORE', 'is not set'),
+                 have_kconfig))]
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.unprivileged_bpf_disabled', '1'),
+             AND(KconfigCheck('cut_attack_surface', 'lockdown', 'BPF_SYSCALL', 'is not set'),
+                 have_kconfig))]
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'vm.unprivileged_userfaultfd', '0'),
              AND(KconfigCheck('cut_attack_surface', 'grsec', 'USERFAULTFD', 'is not set'),
-                 have_config_file))]
+                 have_kconfig))]
           # At first, it disabled unprivileged userfaultfd,
           # and since v5.11 it enables unprivileged userfaultfd for user-mode only.
 
-    l += [OR(SysctlCheck('cut_attack_surface', 'clipos', 'kernel.modules_disabled', '1'), # radical, but may be useful in some cases
+    l += [OR(SysctlCheck('cut_attack_surface', 'clipos', 'kernel.modules_disabled', '1'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
-                 have_config_file))]
+                 have_kconfig))] # radical, but may be useful in some cases
 
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.protected_symlinks', '1')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.protected_hardlinks', '1')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -663,8 +663,9 @@ def add_sysctl_checks(l, _arch):
 # Calling the SysctlCheck class constructor:
 #   SysctlCheck(reason, decision, name, expected)
 
-    # use an omnipresent config symbol to see if we have a config file
-    have_config_file = KconfigCheck('-', '-', 'DEFAULT_INIT', 'is present')
+    # Use an omnipresent kconfig symbol to see if we have a kconfig file for checking
+    have_config_file = KconfigCheck('-', '-', 'LOCALVERSION', 'is present')
+
     l += [OR(SysctlCheck('self_protection', 'kspp', 'net.core.bpf_jit_harden', '2'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'BPF_JIT', 'is not set'),
                  have_config_file))]


### PR DESCRIPTION
Don't fail some sysctl checks if a config option already takes care of it
If called with both a kernel config file and a sysctl file, we can check the former to skip some sysctl checks that are not present because a config option has disabled it.

While at it, let `dev.tty.legacy_tiocsti` not be a failure if not found.  It was added in linux-6.2, so earlier versions will not have it.  Its absence alone is a soft indication that it can't be set.

It could be argued that any of the sysctl checks can be skipped if not found, but I still left the config checks in place, as an extra safeguard.

Switch the symbol used to check a root-generated sysctl file from `net.core.bpf_jit_harden` to `kernel.cad_pid` as the former is not present if JIT is disabled.