### PR TITLE
Add io_uring_disabled similar to CONFIG_IO_URING in kconfig

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -748,6 +748,10 @@ def add_sysctl_checks(l: List[ChecklistObjType], _arch: StrOrNone) -> None:
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
                  have_kconfig))] # radical, but may be useful in some cases
 
+    l += [OR(SysctlCheck('cut_attack_surface', 'grsec', 'kernel.io_uring_disabled', '2'),
+             AND(KconfigCheck('cut_attack_surface', 'grsec', 'IO_URING', 'is not set'),
+                 have_kconfig))] # compatible with the 'IO_URING' kconfig check by grsecurity
+
     l += [OR(SysctlCheck('cut_attack_surface', 'a13xp0p0v', 'kernel.sysrq', '0'),
              AND(KconfigCheck('cut_attack_surface', 'clipos', 'MAGIC_SYSRQ', 'is not set'),
                  have_kconfig))]


### PR DESCRIPTION
References #109 

Added a sysctl io_uring_disabled check, which I believe should be set to 2 for complete disabling. Fully disabling this option reduces the attack surface, as a limited io_uring could still be exploited from rooted namespaces, such as unsecured Docker containers for example. Also, this approach is recommended by Grsecurity and has been implemented in kconfig as fully disabled.



