### PR TITLE
Add kconfig option `CONFIG_CFI_AUTO_DEFAULT` which is twin of `cfi=kcfi`

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -560,7 +560,17 @@ def add_cmdline_checks(l: List[ChecklistObjType], arch: str) -> None:
     l += [CmdlineCheck('self_protection', 'kspp', 'slab_merge', 'is not set')] # consequence of 'slab_nomerge' by kspp
     l += [CmdlineCheck('self_protection', 'kspp', 'slub_merge', 'is not set')] # consequence of 'slab_nomerge' by kspp
     l += [CmdlineCheck('self_protection', 'kspp', 'page_alloc.shuffle', '1')]
-    l += [CmdlineCheck('self_protection', 'kspp', 'cfi', 'kcfi')]
+    cfi_clang_is_set = KconfigCheck('self_protection', 'kspp', 'CFI_CLANG', 'y')
+    cc_is_clang = KconfigCheck('-', '-', 'CC_IS_CLANG', 'y')
+    l += [OR(AND(CmdlineCheck('self_protection', 'kspp', 'cfi', 'kcfi'),
+                 KconfigCheck('self_protection','kspp','CONFIG_CFI_PERMISSIVE','is not set'),
+                 cfi_clang_is_set,
+                 cc_is_clang),
+             AND(KconfigCheck('self_protection','kspp','CONFIG_CFI_AUTO_DEFAULT','is not set'),
+                 KconfigCheck('self_protection','kspp','CONFIG_CFI_PERMISSIVE','is not set'),
+                 cfi_clang_is_set,
+                 cc_is_clang
+             ))]
     l += [OR(CmdlineCheck('self_protection', 'kspp', 'slab_nomerge', 'is present'),
              AND(KconfigCheck('self_protection', 'kspp', 'SLAB_MERGE_DEFAULT', 'is not set'),
                  CmdlineCheck('self_protection', 'kspp', 'slab_merge', 'is not set'),


### PR DESCRIPTION
this release commit is an implementation of #149 

basic things: `OK`is `cfi=kcfi` in __cmdline__. if this parameter is not set, we looking for `CONFIG_CFI_AUTO_DEFAULT` which should be off, it is equals to  `cfi=kcfi`, see [reference](https://patchew.org/linux/20240501000218.work.998-kees@kernel.org/)
also for this Kconfig options we have some dependences, they are also added to check.

important thing: we should specify compiler (From Kees Cook's [slides](https://outflux.net/slides/2020/lca/cfi.pdf))