### PR TITLE
implementation of `CONFIG_CFI_AUTO_DEFAULT `

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -278,8 +278,8 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
 
     # 'self_protection', 'a13xp0p0v'
     if arch == 'X86_64':
-        l += [AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'), # same as 'cfi=kcfi'
-                KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is present'))]
+        l += [AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'),
+                  KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is present'))] # same as 'cfi=kcfi'
     if arch == 'ARM':
         l += [KconfigCheck('self_protection', 'a13xp0p0v', 'ARM_SMMU', 'y')]
         l += [KconfigCheck('self_protection', 'a13xp0p0v', 'ARM_SMMU_DISABLE_BYPASS_BY_DEFAULT', 'y')]
@@ -614,7 +614,7 @@ def add_cmdline_checks(l: List[ChecklistObjType], arch: str) -> None:
                  CmdlineCheck('self_protection', 'kspp', 'mitigations', 'is not set'))] # same as 'auto'
     if arch == 'X86_64':
         l += [OR(CmdlineCheck('self_protection', 'kspp', 'cfi', 'kcfi'),
-                 AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'), # same as 'cfi=kcfi'
+                 AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'),
                      KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is present'),
                      CmdlineCheck('self_protection', 'kspp', 'cfi', 'is not set')))]
 

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -277,6 +277,9 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
                  # DEBUG_WX has been renamed to ARM_DEBUG_WX on ARM
 
     # 'self_protection', 'a13xp0p0v'
+    if arch == 'X86_64':
+        l += [AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'), # same as 'cfi=kcfi'
+                KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is present'))]
     if arch == 'ARM':
         l += [KconfigCheck('self_protection', 'a13xp0p0v', 'ARM_SMMU', 'y')]
         l += [KconfigCheck('self_protection', 'a13xp0p0v', 'ARM_SMMU_DISABLE_BYPASS_BY_DEFAULT', 'y')]
@@ -568,7 +571,6 @@ def add_cmdline_checks(l: List[ChecklistObjType], arch: str) -> None:
     l += [CmdlineCheck('self_protection', 'kspp', 'slab_merge', 'is not set')] # consequence of 'slab_nomerge' by kspp
     l += [CmdlineCheck('self_protection', 'kspp', 'slub_merge', 'is not set')] # consequence of 'slab_nomerge' by kspp
     l += [CmdlineCheck('self_protection', 'kspp', 'page_alloc.shuffle', '1')]
-    l += [CmdlineCheck('self_protection', 'kspp', 'cfi', 'kcfi')]
     l += [OR(CmdlineCheck('self_protection', 'kspp', 'slab_nomerge', 'is present'),
              AND(KconfigCheck('self_protection', 'kspp', 'SLAB_MERGE_DEFAULT', 'is not set'),
                  CmdlineCheck('self_protection', 'kspp', 'slab_merge', 'is not set'),
@@ -610,6 +612,11 @@ def add_cmdline_checks(l: List[ChecklistObjType], arch: str) -> None:
     if arch == 'ARM64':
         l += [OR(CmdlineCheck('self_protection', 'kspp', 'mitigations', 'auto'),
                  CmdlineCheck('self_protection', 'kspp', 'mitigations', 'is not set'))] # same as 'auto'
+    if arch == 'X86_64':
+        l += [OR(CmdlineCheck('self_protection', 'kspp', 'cfi', 'kcfi'),
+                 AND(KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is not set'), # same as 'cfi=kcfi'
+                     KconfigCheck('self_protection', 'a13xp0p0v', 'CFI_AUTO_DEFAULT', 'is present'),
+                     CmdlineCheck('self_protection', 'kspp', 'cfi', 'is not set')))]
 
     # 'self_protection', 'clipos'
     if arch in ('X86_64', 'X86_32'):


### PR DESCRIPTION
there is an implementation of #149

a few words about logic: `OK` is `cfi=kcfi` in __cmdline__. if this parameter is not set, we looking for `CONFIG_CFI_AUTO_DEFAULT` which should be off, it is equals to  `cfi=kcfi`([reference](https://patchew.org/linux/20240501000218.work.998-kees@kernel.org/))
also for kCFI options we have some dependences, they are also added to check.