### PR TITLE
Add an --autodetect option

### DIFF
--- a/.github/workflows/functional_test.sh
+++ b/.github/workflows/functional_test.sh
@@ -41,6 +41,13 @@ coverage run -a --branch bin/kernel-hardening-checker -g X86_32
 coverage run -a --branch bin/kernel-hardening-checker -g ARM64
 coverage run -a --branch bin/kernel-hardening-checker -g ARM
 
+echo ">>>>> try autodetection <<<<<"
+coverage run -a --branch bin/kernel-hardening-checker -a
+coverage run -a --branch bin/kernel-hardening-checker -a -m verbose
+coverage run -a --branch bin/kernel-hardening-checker -a -m json
+coverage run -a --branch bin/kernel-hardening-checker -a -m show_ok
+coverage run -a --branch bin/kernel-hardening-checker -a -m show_fail
+
 echo ">>>>> check the example kconfig files, cmdline, and sysctl <<<<<"
 cat /proc/cmdline
 echo "l1tf=off mds=full mitigations=off randomize_kstack_offset=on retbleed=0 iommu.passthrough=0" > ./cmdline_example

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -41,7 +41,7 @@ def _open(file: str) -> TextIO:
         sys.exit(f'[!] ERROR: unable to open {file}, are you sure it exists?')
 
 
-def detect_arch_kconfig(fname: str) -> Tuple[StrOrNone, str]:
+def detect_arch_by_kconfig(fname: str) -> Tuple[StrOrNone, str]:
     arch = None
 
     with _open(fname) as f:
@@ -60,7 +60,7 @@ def detect_arch_kconfig(fname: str) -> Tuple[StrOrNone, str]:
     return arch, 'OK'
 
 
-def detect_arch_sysctl(fname: str) -> Tuple[StrOrNone, str]:
+def detect_arch_by_sysctl(fname: str) -> Tuple[StrOrNone, str]:
     arch_mapping = {
         'ARM64': r'^aarch64|armv8',
         'ARM': r'^armv[3-7]',
@@ -269,7 +269,7 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
 
     # detect the kernel microarchitecture
     if kconfig:
-        arch, msg = detect_arch_kconfig(kconfig)
+        arch, msg = detect_arch_by_kconfig(kconfig)
         if arch is None:
             sys.exit(f'[!] ERROR: {msg}')
         if mode != 'json':
@@ -277,7 +277,7 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
     else:
         assert(not cmdline), 'wrong perform_checking() usage'
         assert(sysctl), 'wrong perform_checking() usage'
-        arch, msg = detect_arch_sysctl(sysctl)
+        arch, msg = detect_arch_by_sysctl(sysctl)
         if mode != 'json':
             if arch is None:
                 print(f'[!] WARNING: {msg}, arch-dependent checks will be dropped')

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -14,6 +14,9 @@ This module performs input/output.
 import os
 import gzip
 import sys
+import glob
+import tempfile
+import subprocess
 from argparse import ArgumentParser
 from typing import List, Tuple, Dict, TextIO
 import re
@@ -378,6 +381,9 @@ def main() -> None:
                         help='print the security hardening recommendations for the selected microarchitecture')
     parser.add_argument('-g', '--generate', choices=SUPPORTED_ARCHS,
                         help='generate a Kconfig fragment with the security hardening options for the selected microarchitecture')
+    parser.add_argument('-a', '--autodetect',
+                        help='autodetect the running kernel and infer the corresponding Kconfig file',
+                        action='store_true')
     args = parser.parse_args()
 
     mode = None
@@ -385,6 +391,38 @@ def main() -> None:
         mode = args.mode
         if mode != 'json':
             print(f'[+] Special report mode: {mode}')
+
+    if args.autodetect:
+        cmdline = '/proc/cmdline'
+        config = '/proc/config.gz'
+        if os.path.isfile('/proc/config.gz'):
+            kernel_version, msg = detect_kernel_version(config)
+            assert kernel_version
+            kernel_version_str = '.'.join(map(str, kernel_version))
+        else:
+            kernel_version, msg = detect_kernel_version('/proc/version')
+            assert kernel_version
+            kernel_version_str = '.'.join(map(str, kernel_version))
+            config_files = glob.glob(f'/boot/config-{kernel_version_str}-*')
+            if not config_files:
+                sys.exit(f'[!] ERROR: unable to find a Kconfig file for {kernel_version_str}')
+            config = config_files[0]
+            if mode != 'json':
+                if len(config_files) > 1:
+                    print(f'[+] Multiple Kconfig files found for {kernel_version_str}, picking {config}')
+
+        _, tmpfile = tempfile.mkstemp()
+        with open(tmpfile, 'w', encoding='utf-8') as f:
+            subprocess.call(['sysctl', '-a'], stdout=f, stderr=subprocess.DEVNULL, shell=False)
+
+        if mode != 'json':
+            print(f'[+] Detected running kernel version: {kernel_version_str}')
+            print(f'[+] Kconfig file to check: {config}')
+
+        perform_checking(mode, kernel_version, config, cmdline, tmpfile)
+
+        os.remove(tmpfile)
+        sys.exit(0)
 
     if mode != 'json':
         if args.config:

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -375,7 +375,6 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
 
     # finally print the results
     print_checklist(mode, config_checklist, True)
-    sys.exit(0)
 
 
 def main() -> None:

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -38,6 +38,8 @@ def _open(file: str) -> TextIO:
         return open(file, 'rt', encoding='utf-8')
     except FileNotFoundError:
         sys.exit(f'[!] ERROR: unable to open {file}, are you sure it exists?')
+    except PermissionError:
+        sys.exit(f'[!] ERROR: unable to open {file}, permission denied')
 
 
 def detect_kconfig(version_fname: str) -> Tuple[StrOrNone, str]:


### PR DESCRIPTION
Instead of having to specify Kconfig file and `/proc/cmdline`, `--autodetect` will try to infer them.

This is related to #129, and replaces #130.