### PR TITLE
implementation of `arch_mmap_rnd` checks

### DIFF
--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -313,10 +313,12 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
         # populate the checklist with the parsed Kconfig data
         parse_kconfig_file(mode, parsed_kconfig_options, kconfig)
         populate_with_data(config_checklist, parsed_kconfig_options, 'kconfig')
+        # refine the values of some checks
         refine_check(mode, config_checklist, parsed_kconfig_options,
                      'CONFIG_ARCH_MMAP_RND_BITS', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
         refine_check(mode, config_checklist, parsed_kconfig_options,
                      'CONFIG_ARCH_MMAP_RND_COMPAT_BITS', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX')
+        # and don't forget to skip these Kconfig checks in --generate
 
     if cmdline:
         # populate the checklist with the parsed cmdline data
@@ -329,6 +331,7 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
         parsed_sysctl_options = {} # type: Dict[str, str]
         parse_sysctl_file(mode, parsed_sysctl_options, sysctl)
         populate_with_data(config_checklist, parsed_sysctl_options, 'sysctl')
+        # refine the values of some checks
         refine_check(mode, config_checklist, parsed_kconfig_options,
                      'vm.mmap_rnd_bits', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
         refine_check(mode, config_checklist, parsed_kconfig_options,
@@ -451,8 +454,8 @@ def main() -> None:
         add_kconfig_checks(config_checklist, arch)
         print(f'CONFIG_{arch}=y') # the Kconfig fragment should describe the microarchitecture
         for opt in config_checklist:
-            if opt.name == 'CONFIG_ARCH_MMAP_RND_BITS':
-                continue # don't add CONFIG_ARCH_MMAP_RND_BITS because its value needs refinement
+            if opt.name in ('CONFIG_ARCH_MMAP_RND_BITS', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS'):
+                continue # don't add Kconfig options with a value that needs refinement
             if opt.expected == 'is not off':
                 continue # don't add Kconfig options without explicitly recommended values
             if opt.expected == 'is not set':

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -247,10 +247,11 @@ def parse_sysctl_file(mode: StrOrNone, parsed_options: Dict[str, str], fname: st
         print(f'[!] WARNING: sysctl options available for root are not found in {fname}, please use the output of `sudo sysctl -a`')
 
 
-def refine_check(mode: StrOrNone, checklist: List[ChecklistObjType], parsed_options: Dict[str, str], target: str, source: str) -> None:
-    source_option = parsed_options.get(source, None)
-    if source_option:
-        override_expected_value(checklist, target, source_option)
+def refine_check(mode: StrOrNone, checklist: List[ChecklistObjType], parsed_options: Dict[str, str],
+                 target: str, source: str) -> None:
+    source_val = parsed_options.get(source, None)
+    if source_val:
+        override_expected_value(checklist, target, source_val)
     else:
         # remove the target check to avoid false results
         if mode != 'json':
@@ -312,8 +313,10 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
         # populate the checklist with the parsed Kconfig data
         parse_kconfig_file(mode, parsed_kconfig_options, kconfig)
         populate_with_data(config_checklist, parsed_kconfig_options, 'kconfig')
-        refine_check(mode, config_checklist, parsed_kconfig_options, 'CONFIG_ARCH_MMAP_RND_BITS', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
-        refine_check(mode, config_checklist, parsed_kconfig_options, 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX')
+        refine_check(mode, config_checklist, parsed_kconfig_options,
+                     'CONFIG_ARCH_MMAP_RND_BITS', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
+        refine_check(mode, config_checklist, parsed_kconfig_options,
+                     'CONFIG_ARCH_MMAP_RND_COMPAT_BITS', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX')
 
     if cmdline:
         # populate the checklist with the parsed cmdline data
@@ -326,8 +329,10 @@ def perform_checking(mode: StrOrNone, version: TupleOrNone,
         parsed_sysctl_options = {} # type: Dict[str, str]
         parse_sysctl_file(mode, parsed_sysctl_options, sysctl)
         populate_with_data(config_checklist, parsed_sysctl_options, 'sysctl')
-        refine_check(mode, config_checklist, parsed_kconfig_options, 'vm.mmap_rnd_bits', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
-        refine_check(mode, config_checklist, parsed_kconfig_options, 'vm.mmap_rnd_compat_bits', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX')
+        refine_check(mode, config_checklist, parsed_kconfig_options,
+                     'vm.mmap_rnd_bits', 'CONFIG_ARCH_MMAP_RND_BITS_MAX')
+        refine_check(mode, config_checklist, parsed_kconfig_options,
+                     'vm.mmap_rnd_compat_bits', 'CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX')
 
     # now everything is ready, perform the checks
     perform_checks(config_checklist)

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -471,8 +471,10 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
     if arch in ('ARM', 'X86_32'):
         l += [KconfigCheck('harden_userspace', 'defconfig', 'VMSPLIT_3G', 'y')]
     l += [KconfigCheck('harden_userspace', 'clipos', 'COREDUMP', 'is not set')]
-    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_BITS', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
-    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_COMPAT_BITS', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX
+    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_BITS', 'MAX')]
+                       # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
+    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_COMPAT_BITS', 'MAX')]
+                       # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX
     if arch == 'X86_64':
         l += [KconfigCheck('harden_userspace', 'kspp', 'X86_USER_SHADOW_STACK', 'y')]
 
@@ -789,5 +791,7 @@ def add_sysctl_checks(l: List[ChecklistObjType], arch: StrOrNone) -> None:
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.suid_dumpable', '0')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'kernel.randomize_va_space', '2')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'kernel.yama.ptrace_scope', '3')]
-    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_bits', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
-    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_compat_bits', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX
+    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_bits', 'MAX')]
+                      # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
+    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_compat_bits', 'MAX')]
+                      # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -472,6 +472,7 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
         l += [KconfigCheck('harden_userspace', 'defconfig', 'VMSPLIT_3G', 'y')]
     l += [KconfigCheck('harden_userspace', 'clipos', 'COREDUMP', 'is not set')]
     l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_BITS', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
+    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_COMPAT_BITS', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX
     if arch == 'X86_64':
         l += [KconfigCheck('harden_userspace', 'kspp', 'X86_USER_SHADOW_STACK', 'y')]
 
@@ -788,3 +789,5 @@ def add_sysctl_checks(l: List[ChecklistObjType], arch: StrOrNone) -> None:
     l += [SysctlCheck('harden_userspace', 'kspp', 'fs.suid_dumpable', '0')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'kernel.randomize_va_space', '2')]
     l += [SysctlCheck('harden_userspace', 'kspp', 'kernel.yama.ptrace_scope', '3')]
+    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_bits', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_BITS_MAX
+    l += [SysctlCheck('harden_userspace', 'a13xp0p0v', 'vm.mmap_rnd_compat_bits', 'MAX')] # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX


### PR DESCRIPTION
reffering to #146, i implemented this cheks
we cant check maximum and minimum random offets through `sysctl` (please, see [my comments here](https://github.com/a13xp0p0v/kernel-hardening-checker/issues/146))