### PR TITLE
Reorder output tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ options:
 ```
 -------------------------------------------------------------------------------------------
     <<< OR >>>                                                                             
-CONFIG_STRICT_DEVMEM                    |kconfig|     y      |defconfig |cut_attack_surface
-CONFIG_DEVMEM                           |kconfig| is not set |   kspp   |cut_attack_surface
+CONFIG_STRICT_DEVMEM                  |kconfig|cut_attack_surface|defconfig |     y      
+CONFIG_DEVMEM                         |kconfig|cut_attack_surface|   kspp   | is not set 
 -------------------------------------------------------------------------------------------
 ```
   - `-m show_fail` for showing only the failed checks
@@ -133,316 +133,316 @@ $ ./bin/kernel-hardening-checker -a
 [+] Detected version of the running kernel: (6, 11, 0)
 [+] Detected kconfig file of the running kernel: /boot/config-6.11.0-1012-azure
 [+] Detected cmdline parameters of the running kernel: /proc/cmdline
-[+] Saved sysctls to a temporary file /tmp/sysctl-d0j9yhrh
+[+] Saved sysctls to a temporary file /tmp/sysctl-bticbl3p
 [+] Detected architecture: X86_64
 [+] Detected compiler: GCC 130300
 [!] WARNING: cmdline option "console" is found multiple times
-[!] WARNING: sysctl options available for root are not found in /tmp/sysctl-d0j9yhrh, try checking the output of `sudo sysctl -a`
+[!] WARNING: sysctl options available for root are not found in /tmp/sysctl-bticbl3p, try checking the output of `sudo sysctl -a`
 =========================================================================================================================
-              option_name               | type  |desired_val | decision |      reason      | check_result
+             option_name              | type  |      reason      | decision |desired_val | check_result
 =========================================================================================================================
-CONFIG_BUG                              |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_SLUB_DEBUG                       |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_THREAD_INFO_IN_TASK              |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_IOMMU_DEFAULT_PASSTHROUGH        |kconfig| is not set |defconfig | self_protection  | OK
-CONFIG_IOMMU_SUPPORT                    |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_STACKPROTECTOR                   |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_STACKPROTECTOR_STRONG            |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_STRICT_KERNEL_RWX                |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_STRICT_MODULE_RWX                |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_REFCOUNT_FULL                    |kconfig|     y      |defconfig | self_protection  | OK: version >= (5, 4, 208)
-CONFIG_INIT_STACK_ALL_ZERO              |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_CPU_MITIGATIONS                  |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_RANDOMIZE_BASE                   |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_VMAP_STACK                       |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_DEBUG_WX                         |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_WERROR                           |kconfig|     y      |defconfig | self_protection  | FAIL: "is not set"
-CONFIG_X86_MCE                          |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_SYN_COOKIES                      |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MICROCODE                        |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MICROCODE_INTEL                  |kconfig|     y      |defconfig | self_protection  | OK: CONFIG_MICROCODE is "y"
-CONFIG_MICROCODE_AMD                    |kconfig|     y      |defconfig | self_protection  | OK: CONFIG_MICROCODE is "y"
-CONFIG_X86_SMAP                         |kconfig|     y      |defconfig | self_protection  | OK: version >= (5, 19, 0)
-CONFIG_X86_UMIP                         |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_X86_MCE_INTEL                    |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_X86_MCE_AMD                      |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MITIGATION_RETPOLINE             |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MITIGATION_RFDS                  |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MITIGATION_SPECTRE_BHI           |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_RANDOMIZE_MEMORY                 |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_X86_KERNEL_IBT                   |kconfig|     y      |defconfig | self_protection  | FAIL: "is not set"
-CONFIG_MITIGATION_PAGE_TABLE_ISOLATION  |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_MITIGATION_SRSO                  |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_INTEL_IOMMU                      |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_AMD_IOMMU                        |kconfig|     y      |defconfig | self_protection  | OK
-CONFIG_RANDOM_KMALLOC_CACHES            |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_SLAB_MERGE_DEFAULT               |kconfig| is not set |   kspp   | self_protection  | FAIL: "y"
-CONFIG_BUG_ON_DATA_CORRUPTION           |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_SLAB_FREELIST_HARDENED           |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_SLAB_FREELIST_RANDOM             |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_SHUFFLE_PAGE_ALLOCATOR           |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_FORTIFY_SOURCE                   |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_DEBUG_VIRTUAL                    |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_INIT_ON_ALLOC_DEFAULT_ON         |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_STATIC_USERMODEHELPER            |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_SECURITY_LOCKDOWN_LSM            |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_LSM                              |kconfig| *lockdown* |   kspp   | self_protection  | OK: in "landlock,lockdown,yama,integrity,apparmor"
-CONFIG_SECURITY_LOCKDOWN_LSM_EARLY      |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_LOCK_DOWN_KERNEL_FORCE_CONFIDENTIALITY|kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_DEBUG_CREDENTIALS                |kconfig|     y      |   kspp   | self_protection  | OK: version >= (6, 6, 8)
-CONFIG_DEBUG_NOTIFIERS                  |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_KFENCE                           |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_KFENCE_SAMPLE_INTERVAL           |kconfig|    100     |   kspp   | self_protection  | FAIL: "0"
-CONFIG_RANDSTRUCT_FULL                  |kconfig|     y      |   kspp   | self_protection  | FAIL: is not found
-CONFIG_HARDENED_USERCOPY                |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_HARDENED_USERCOPY_FALLBACK       |kconfig| is not set |   kspp   | self_protection  | OK: is not found
-CONFIG_HARDENED_USERCOPY_PAGESPAN       |kconfig| is not set |   kspp   | self_protection  | OK: is not found
-CONFIG_GCC_PLUGIN_LATENT_ENTROPY        |kconfig|     y      |   kspp   | self_protection  | FAIL: is not found
-CONFIG_MODULE_SIG                       |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_MODULE_SIG_ALL                   |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_MODULE_SIG_SHA512                |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_MODULE_SIG_FORCE                 |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_INIT_ON_FREE_DEFAULT_ON          |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_EFI_DISABLE_PCI_DMA              |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_RESET_ATTACK_MITIGATION          |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_UBSAN_BOUNDS                     |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_UBSAN_LOCAL_BOUNDS               |kconfig|     y      |   kspp   | self_protection  | OK: CONFIG_UBSAN_BOUNDS is "y"
-CONFIG_UBSAN_TRAP                       |kconfig|     y      |   kspp   | self_protection  | FAIL: CONFIG_UBSAN_ENUM is not "is not set"
-CONFIG_UBSAN_SANITIZE_ALL               |kconfig|     y      |   kspp   | self_protection  | OK: CONFIG_UBSAN_BOUNDS is "y"
-CONFIG_SCHED_CORE                       |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_DEBUG_SG                         |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_LIST_HARDENED                    |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_SCHED_STACK_END_CHECK            |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT  |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_DEFAULT_MMAP_MIN_ADDR            |kconfig|   65536    |   kspp   | self_protection  | OK
-CONFIG_GCC_PLUGIN_STACKLEAK             |kconfig|     y      |   kspp   | self_protection  | FAIL: is not found
-CONFIG_STACKLEAK_METRICS                |kconfig| is not set |   kspp   | self_protection  | FAIL: CONFIG_GCC_PLUGIN_STACKLEAK is not "y"
-CONFIG_STACKLEAK_RUNTIME_DISABLE        |kconfig| is not set |   kspp   | self_protection  | FAIL: CONFIG_GCC_PLUGIN_STACKLEAK is not "y"
-CONFIG_PAGE_TABLE_CHECK                 |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_PAGE_TABLE_CHECK_ENFORCED        |kconfig|     y      |   kspp   | self_protection  | FAIL: is not found
-CONFIG_HW_RANDOM_TPM                    |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_CFI_CLANG                        |kconfig|     y      |   kspp   | self_protection  | FAIL: CONFIG_CC_IS_CLANG is not "y"
-CONFIG_CFI_PERMISSIVE                   |kconfig| is not set |   kspp   | self_protection  | FAIL: CONFIG_CC_IS_CLANG is not "y"
-CONFIG_IOMMU_DEFAULT_DMA_STRICT         |kconfig|     y      |   kspp   | self_protection  | FAIL: "is not set"
-CONFIG_INTEL_IOMMU_DEFAULT_ON           |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_MITIGATION_SLS                   |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_INTEL_IOMMU_SVM                  |kconfig|     y      |   kspp   | self_protection  | OK
-CONFIG_AMD_IOMMU_V2                     |kconfig|     y      |   kspp   | self_protection  | OK: version >= (6, 7, 0)
-CONFIG_CFI_AUTO_DEFAULT                 |kconfig| is not set |a13xp0p0v | self_protection  | FAIL: CONFIG_CFI_AUTO_DEFAULT is not present
-CONFIG_SECURITY                         |kconfig|     y      |defconfig | security_policy  | OK
-CONFIG_SECURITY_YAMA                    |kconfig|     y      |   kspp   | security_policy  | OK
-CONFIG_LSM                              |kconfig|   *yama*   |   kspp   | security_policy  | OK: in "landlock,lockdown,yama,integrity,apparmor"
-CONFIG_SECURITY_LANDLOCK                |kconfig|     y      |   kspp   | security_policy  | OK
-CONFIG_LSM                              |kconfig| *landlock* |   kspp   | security_policy  | OK: in "landlock,lockdown,yama,integrity,apparmor"
-CONFIG_SECURITY_SELINUX_DISABLE         |kconfig| is not set |   kspp   | security_policy  | OK: is not found
-CONFIG_SECURITY_SELINUX_BOOTPARAM       |kconfig| is not set |   kspp   | security_policy  | FAIL: "y"
-CONFIG_SECURITY_SELINUX_DEVELOP         |kconfig| is not set |   kspp   | security_policy  | FAIL: "y"
-CONFIG_SECURITY_WRITABLE_HOOKS          |kconfig| is not set |   kspp   | security_policy  | OK: is not found
-CONFIG_SECURITY_SELINUX_DEBUG           |kconfig| is not set |   kspp   | security_policy  | OK
-CONFIG_SECURITY_SELINUX                 |kconfig|     y      |a13xp0p0v | security_policy  | OK
-CONFIG_LSM                              |kconfig| *selinux*  |a13xp0p0v | security_policy  | OK: "apparmor" is in CONFIG_LSM
-CONFIG_SECCOMP                          |kconfig|     y      |defconfig |cut_attack_surface| OK
-CONFIG_SECCOMP_FILTER                   |kconfig|     y      |defconfig |cut_attack_surface| OK
-CONFIG_BPF_UNPRIV_DEFAULT_OFF           |kconfig|     y      |defconfig |cut_attack_surface| OK
-CONFIG_STRICT_DEVMEM                    |kconfig|     y      |defconfig |cut_attack_surface| OK
-CONFIG_X86_INTEL_TSX_MODE_OFF           |kconfig|     y      |defconfig |cut_attack_surface| OK
-CONFIG_SECURITY_DMESG_RESTRICT          |kconfig|     y      |   kspp   |cut_attack_surface| OK
-CONFIG_ACPI_CUSTOM_METHOD               |kconfig| is not set |   kspp   |cut_attack_surface| OK: is not found
-CONFIG_COMPAT_BRK                       |kconfig| is not set |   kspp   |cut_attack_surface| OK
-CONFIG_DEVKMEM                          |kconfig| is not set |   kspp   |cut_attack_surface| OK: is not found
-CONFIG_BINFMT_MISC                      |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "m"
-CONFIG_INET_DIAG                        |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "m"
-CONFIG_KEXEC                            |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_PROC_KCORE                       |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_LEGACY_PTYS                      |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_HIBERNATION                      |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_COMPAT                           |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_IA32_EMULATION                   |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_X86_X32                          |kconfig| is not set |   kspp   |cut_attack_surface| OK: is not found
-CONFIG_X86_X32_ABI                      |kconfig| is not set |   kspp   |cut_attack_surface| OK
-CONFIG_MODIFY_LDT_SYSCALL               |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_OABI_COMPAT                      |kconfig| is not set |   kspp   |cut_attack_surface| OK: is not found
-CONFIG_X86_MSR                          |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "m"
-CONFIG_LEGACY_TIOCSTI                   |kconfig| is not set |   kspp   |cut_attack_surface| OK
-CONFIG_MODULE_FORCE_LOAD                |kconfig| is not set |   kspp   |cut_attack_surface| OK
-CONFIG_MODULES                          |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_DEVMEM                           |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_IO_STRICT_DEVMEM                 |kconfig|     y      |   kspp   |cut_attack_surface| FAIL: "is not set"
-CONFIG_LDISC_AUTOLOAD                   |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_X86_VSYSCALL_EMULATION           |kconfig| is not set |   kspp   |cut_attack_surface| FAIL: "y"
-CONFIG_COMPAT_VDSO                      |kconfig| is not set |   kspp   |cut_attack_surface| OK
-CONFIG_DRM_LEGACY                       |kconfig| is not set |maintainer|cut_attack_surface| OK: is not found
-CONFIG_FB                               |kconfig| is not set |maintainer|cut_attack_surface| FAIL: "y"
-CONFIG_VT                               |kconfig| is not set |maintainer|cut_attack_surface| FAIL: "y"
-CONFIG_BLK_DEV_FD                       |kconfig| is not set |maintainer|cut_attack_surface| OK
-CONFIG_BLK_DEV_FD_RAWCMD                |kconfig| is not set |maintainer|cut_attack_surface| OK: is not found
-CONFIG_NOUVEAU_LEGACY_CTX_SUPPORT       |kconfig| is not set |maintainer|cut_attack_surface| OK: is not found
-CONFIG_N_GSM                            |kconfig| is not set |maintainer|cut_attack_surface| FAIL: "m"
-CONFIG_ZSMALLOC_STAT                    |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_DEBUG_KMEMLEAK                   |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_BINFMT_AOUT                      |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_KPROBE_EVENTS                    |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_UPROBE_EVENTS                    |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_GENERIC_TRACER                   |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_FUNCTION_TRACER                  |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_STACK_TRACER                     |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_HIST_TRIGGERS                    |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_BLK_DEV_IO_TRACE                 |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_PROC_VMCORE                      |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_PROC_PAGE_MONITOR                |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_USELIB                           |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_CHECKPOINT_RESTORE               |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_USERFAULTFD                      |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_HWPOISON_INJECT                  |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_MEM_SOFT_DIRTY                   |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_DEVPORT                          |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_DEBUG_FS                         |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_NOTIFIER_ERROR_INJECTION         |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_FAIL_FUTEX                       |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_PUNIT_ATOM_DEBUG                 |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_ACPI_CONFIGFS                    |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_EDAC_DEBUG                       |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_DRM_I915_DEBUG                   |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_DVB_C8SECTPFE                    |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_MTD_SLRAM                        |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_MTD_PHRAM                        |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_IO_URING                         |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_KCMP                             |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_RSEQ                             |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_LATENCYTOP                       |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_KCOV                             |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_PROVIDE_OHCI1394_DMA_INIT        |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_SUNRPC_DEBUG                     |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_X86_16BIT                        |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_BLK_DEV_UBLK                     |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_SMB_SERVER                       |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_XFS_ONLINE_SCRUB_STATS           |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_CACHESTAT_SYSCALL                |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_PREEMPTIRQ_TRACEPOINTS           |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_ENABLE_DEFAULT_TRACERS           |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_PROVE_LOCKING                    |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_TEST_DEBUG_VIRTUAL               |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_MPTCP                            |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_TLS                              |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_TIPC                             |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_IP_SCTP                          |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "m"
-CONFIG_KGDB                             |kconfig| is not set |  grsec   |cut_attack_surface| FAIL: "y"
-CONFIG_PTDUMP_DEBUGFS                   |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_X86_PTDUMP                       |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_DEBUG_CLOSURES                   |kconfig| is not set |  grsec   |cut_attack_surface| OK
-CONFIG_BCACHE_CLOSURES_DEBUG            |kconfig| is not set |  grsec   |cut_attack_surface| OK: is not found
-CONFIG_STAGING                          |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_KSM                              |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_KALLSYMS                         |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_KEXEC_FILE                       |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_CRASH_DUMP                       |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_USER_NS                          |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_X86_CPUID                        |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "m"
-CONFIG_X86_IOPL_IOPERM                  |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_ACPI_TABLE_UPGRADE               |kconfig| is not set |  clipos  |cut_attack_surface| OK
-CONFIG_EFI_CUSTOM_SSDT_OVERLAYS         |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_AIO                              |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_MAGIC_SYSRQ                      |kconfig| is not set |  clipos  |cut_attack_surface| FAIL: "y"
-CONFIG_MAGIC_SYSRQ_SERIAL               |kconfig| is not set |grapheneos|cut_attack_surface| FAIL: "y"
-CONFIG_EFI_TEST                         |kconfig| is not set | lockdown |cut_attack_surface| FAIL: "m"
-CONFIG_MMIOTRACE_TEST                   |kconfig| is not set | lockdown |cut_attack_surface| OK
-CONFIG_KPROBES                          |kconfig| is not set | lockdown |cut_attack_surface| FAIL: "y"
-CONFIG_BPF_SYSCALL                      |kconfig| is not set | lockdown |cut_attack_surface| FAIL: "y"
-CONFIG_MMIOTRACE                        |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "y"
-CONFIG_LIVEPATCH                        |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "y"
-CONFIG_IP_DCCP                          |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "m"
-CONFIG_FTRACE                           |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "y"
-CONFIG_VIDEO_VIVID                      |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "m"
-CONFIG_INPUT_EVBUG                      |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "m"
-CONFIG_CORESIGHT                        |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK: is not found
-CONFIG_XFS_SUPPORT_V4                   |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "y"
-CONFIG_BLK_DEV_WRITE_MOUNTED            |kconfig| is not set |a13xp0p0v |cut_attack_surface| FAIL: "y"
-CONFIG_FAULT_INJECTION                  |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK
-CONFIG_ARM_PTDUMP_DEBUGFS               |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK: is not found
-CONFIG_ARM_PTDUMP                       |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK: is not found
-CONFIG_SECCOMP_CACHE_DEBUG              |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK
-CONFIG_LKDTM                            |kconfig| is not set |a13xp0p0v |cut_attack_surface| OK
-CONFIG_TRIM_UNUSED_KSYMS                |kconfig|     y      |a13xp0p0v |cut_attack_surface| FAIL: "is not set"
-CONFIG_COREDUMP                         |kconfig| is not set |  clipos  | harden_userspace | FAIL: "y"
-CONFIG_ARCH_MMAP_RND_BITS               |kconfig|     32     |a13xp0p0v | harden_userspace | OK
-CONFIG_ARCH_MMAP_RND_COMPAT_BITS        |kconfig|     16     |a13xp0p0v | harden_userspace | OK
-CONFIG_X86_USER_SHADOW_STACK            |kconfig|     y      |   kspp   | harden_userspace | OK
-nosmep                                  |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nosmap                                  |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nokaslr                                 |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nopti                                   |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nospectre_v1                            |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nospectre_v2                            |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nospectre_bhb                           |cmdline| is not set |defconfig | self_protection  | OK: is not found
-nospec_store_bypass_disable             |cmdline| is not set |defconfig | self_protection  | OK: is not found
-dis_ucode_ldr                           |cmdline| is not set |defconfig | self_protection  | OK: is not found
-arm64.nobti                             |cmdline| is not set |defconfig | self_protection  | OK: is not found
-arm64.nopauth                           |cmdline| is not set |defconfig | self_protection  | OK: is not found
-arm64.nomte                             |cmdline| is not set |defconfig | self_protection  | OK: is not found
-iommu.passthrough                       |cmdline|     0      |defconfig | self_protection  | OK: CONFIG_IOMMU_DEFAULT_PASSTHROUGH is "is not set"
-rodata                                  |cmdline|     on     |defconfig | self_protection  | OK: rodata is not found
-spectre_v2                              |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-spectre_v2_user                         |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-spectre_bhi                             |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-spec_store_bypass_disable               |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-l1tf                                    |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-mds                                     |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-tsx_async_abort                         |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-srbds                                   |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-mmio_stale_data                         |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-retbleed                                |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-spec_rstack_overflow                    |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-gather_data_sampling                    |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-reg_file_data_sampling                  |cmdline| is not off |defconfig | self_protection  | FAIL: is off, not found
-slab_merge                              |cmdline| is not set |   kspp   | self_protection  | OK: is not found
-slub_merge                              |cmdline| is not set |   kspp   | self_protection  | OK: is not found
-page_alloc.shuffle                      |cmdline|     1      |   kspp   | self_protection  | FAIL: is not found
-slab_nomerge                            |cmdline| is present |   kspp   | self_protection  | FAIL: is not present
-init_on_alloc                           |cmdline|     1      |   kspp   | self_protection  | OK: CONFIG_INIT_ON_ALLOC_DEFAULT_ON is "y"
-init_on_free                            |cmdline|     1      |   kspp   | self_protection  | FAIL: is not found
-hardened_usercopy                       |cmdline|     1      |   kspp   | self_protection  | OK: CONFIG_HARDENED_USERCOPY is "y"
-slab_common.usercopy_fallback           |cmdline| is not set |   kspp   | self_protection  | OK: is not found
-kfence.sample_interval                  |cmdline|    100     |   kspp   | self_protection  | FAIL: is not found
-randomize_kstack_offset                 |cmdline|     1      |   kspp   | self_protection  | OK: CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT is "y"
-mitigations                             |cmdline| auto,nosmt |   kspp   | self_protection  | FAIL: is not found
-iommu.strict                            |cmdline|     1      |   kspp   | self_protection  | FAIL: is not found
-pti                                     |cmdline|     on     |   kspp   | self_protection  | FAIL: is not found
-cfi                                     |cmdline|    kcfi    |   kspp   | self_protection  | FAIL: is not found
-iommu                                   |cmdline|   force    |  clipos  | self_protection  | FAIL: is not found
-tsx                                     |cmdline|    off     |defconfig |cut_attack_surface| OK: CONFIG_X86_INTEL_TSX_MODE_OFF is "y"
-nosmt                                   |cmdline| is present |   kspp   |cut_attack_surface| FAIL: is not present
-vsyscall                                |cmdline|    none    |   kspp   |cut_attack_surface| FAIL: is not found
-vdso32                                  |cmdline|     0      |   kspp   |cut_attack_surface| OK: CONFIG_COMPAT_VDSO is "is not set"
-debugfs                                 |cmdline|    off     |  grsec   |cut_attack_surface| FAIL: is not found
-sysrq_always_enabled                    |cmdline| is not set |grapheneos|cut_attack_surface| OK: is not found
-bdev_allow_write_mounted                |cmdline|     0      |a13xp0p0v |cut_attack_surface| FAIL: is not found
-ia32_emulation                          |cmdline|     0      |a13xp0p0v |cut_attack_surface| FAIL: is not found
-norandmaps                              |cmdline| is not set |defconfig | harden_userspace | OK: is not found
-net.core.bpf_jit_harden                 |sysctl |     2      |   kspp   | self_protection  | FAIL: is not found
-kernel.oops_limit                       |sysctl |    100     |a13xp0p0v | self_protection  | FAIL: "10000"
-kernel.warn_limit                       |sysctl |    100     |a13xp0p0v | self_protection  | FAIL: "0"
-vm.mmap_min_addr                        |sysctl |   65536    |   kspp   | self_protection  | OK
-kernel.dmesg_restrict                   |sysctl |     1      |   kspp   |cut_attack_surface| OK
-kernel.perf_event_paranoid              |sysctl |     3      |   kspp   |cut_attack_surface| FAIL: "4"
-dev.tty.ldisc_autoload                  |sysctl |     0      |   kspp   |cut_attack_surface| FAIL: "1"
-kernel.kptr_restrict                    |sysctl |     2      |   kspp   |cut_attack_surface| FAIL: "1"
-dev.tty.legacy_tiocsti                  |sysctl |     0      |   kspp   |cut_attack_surface| OK
-user.max_user_namespaces                |sysctl |     0      |   kspp   |cut_attack_surface| FAIL: "63936"
-kernel.kexec_load_disabled              |sysctl |     1      |   kspp   |cut_attack_surface| FAIL: "0"
-kernel.unprivileged_bpf_disabled        |sysctl |     1      |   kspp   |cut_attack_surface| FAIL: "2"
-vm.unprivileged_userfaultfd             |sysctl |     0      |   kspp   |cut_attack_surface| OK
-kernel.modules_disabled                 |sysctl |     1      |   kspp   |cut_attack_surface| FAIL: "0"
-kernel.io_uring_disabled                |sysctl |     2      |  grsec   |cut_attack_surface| FAIL: "0"
-kernel.sysrq                            |sysctl |     0      |a13xp0p0v |cut_attack_surface| FAIL: "176"
-fs.protected_symlinks                   |sysctl |     1      |   kspp   | harden_userspace | OK
-fs.protected_hardlinks                  |sysctl |     1      |   kspp   | harden_userspace | OK
-fs.protected_fifos                      |sysctl |     2      |   kspp   | harden_userspace | FAIL: "1"
-fs.protected_regular                    |sysctl |     2      |   kspp   | harden_userspace | OK
-fs.suid_dumpable                        |sysctl |     0      |   kspp   | harden_userspace | FAIL: "2"
-kernel.randomize_va_space               |sysctl |     2      |   kspp   | harden_userspace | OK
-kernel.yama.ptrace_scope                |sysctl |     3      |   kspp   | harden_userspace | FAIL: "1"
-vm.mmap_rnd_bits                        |sysctl |     32     |a13xp0p0v | harden_userspace | FAIL: is not found
-vm.mmap_rnd_compat_bits                 |sysctl |     16     |a13xp0p0v | harden_userspace | FAIL: is not found
+CONFIG_BUG                            |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_SLUB_DEBUG                     |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_THREAD_INFO_IN_TASK            |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_IOMMU_DEFAULT_PASSTHROUGH      |kconfig| self_protection  |defconfig | is not set | OK
+CONFIG_IOMMU_SUPPORT                  |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_STACKPROTECTOR                 |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_STACKPROTECTOR_STRONG          |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_STRICT_KERNEL_RWX              |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_STRICT_MODULE_RWX              |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_REFCOUNT_FULL                  |kconfig| self_protection  |defconfig |     y      | OK: version >= (5, 4, 208)
+CONFIG_INIT_STACK_ALL_ZERO            |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_CPU_MITIGATIONS                |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_RANDOMIZE_BASE                 |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_VMAP_STACK                     |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_DEBUG_WX                       |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_WERROR                         |kconfig| self_protection  |defconfig |     y      | FAIL: "is not set"
+CONFIG_X86_MCE                        |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_SYN_COOKIES                    |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MICROCODE                      |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MICROCODE_INTEL                |kconfig| self_protection  |defconfig |     y      | OK: CONFIG_MICROCODE is "y"
+CONFIG_MICROCODE_AMD                  |kconfig| self_protection  |defconfig |     y      | OK: CONFIG_MICROCODE is "y"
+CONFIG_X86_SMAP                       |kconfig| self_protection  |defconfig |     y      | OK: version >= (5, 19, 0)
+CONFIG_X86_UMIP                       |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_X86_MCE_INTEL                  |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_X86_MCE_AMD                    |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MITIGATION_RETPOLINE           |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MITIGATION_RFDS                |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MITIGATION_SPECTRE_BHI         |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_RANDOMIZE_MEMORY               |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_X86_KERNEL_IBT                 |kconfig| self_protection  |defconfig |     y      | FAIL: "is not set"
+CONFIG_MITIGATION_PAGE_TABLE_ISOLATION|kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_MITIGATION_SRSO                |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_INTEL_IOMMU                    |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_AMD_IOMMU                      |kconfig| self_protection  |defconfig |     y      | OK
+CONFIG_RANDOM_KMALLOC_CACHES          |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_SLAB_MERGE_DEFAULT             |kconfig| self_protection  |   kspp   | is not set | FAIL: "y"
+CONFIG_BUG_ON_DATA_CORRUPTION         |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_SLAB_FREELIST_HARDENED         |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_SLAB_FREELIST_RANDOM           |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_SHUFFLE_PAGE_ALLOCATOR         |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_FORTIFY_SOURCE                 |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_DEBUG_VIRTUAL                  |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_INIT_ON_ALLOC_DEFAULT_ON       |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_STATIC_USERMODEHELPER          |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_SECURITY_LOCKDOWN_LSM          |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_LSM                            |kconfig| self_protection  |   kspp   | *lockdown* | OK: in "landlock,lockdown,yama,integrity,apparmor"
+CONFIG_SECURITY_LOCKDOWN_LSM_EARLY    |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_LOCK_DOWN_KERNEL_FORCE_CONFIDENTIALITY|kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_DEBUG_CREDENTIALS              |kconfig| self_protection  |   kspp   |     y      | OK: version >= (6, 6, 8)
+CONFIG_DEBUG_NOTIFIERS                |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_KFENCE                         |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_KFENCE_SAMPLE_INTERVAL         |kconfig| self_protection  |   kspp   |    100     | FAIL: "0"
+CONFIG_RANDSTRUCT_FULL                |kconfig| self_protection  |   kspp   |     y      | FAIL: is not found
+CONFIG_HARDENED_USERCOPY              |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_HARDENED_USERCOPY_FALLBACK     |kconfig| self_protection  |   kspp   | is not set | OK: is not found
+CONFIG_HARDENED_USERCOPY_PAGESPAN     |kconfig| self_protection  |   kspp   | is not set | OK: is not found
+CONFIG_GCC_PLUGIN_LATENT_ENTROPY      |kconfig| self_protection  |   kspp   |     y      | FAIL: is not found
+CONFIG_MODULE_SIG                     |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_MODULE_SIG_ALL                 |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_MODULE_SIG_SHA512              |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_MODULE_SIG_FORCE               |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_INIT_ON_FREE_DEFAULT_ON        |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_EFI_DISABLE_PCI_DMA            |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_RESET_ATTACK_MITIGATION        |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_UBSAN_BOUNDS                   |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_UBSAN_LOCAL_BOUNDS             |kconfig| self_protection  |   kspp   |     y      | OK: CONFIG_UBSAN_BOUNDS is "y"
+CONFIG_UBSAN_TRAP                     |kconfig| self_protection  |   kspp   |     y      | FAIL: CONFIG_UBSAN_ENUM is not "is not set"
+CONFIG_UBSAN_SANITIZE_ALL             |kconfig| self_protection  |   kspp   |     y      | OK: CONFIG_UBSAN_BOUNDS is "y"
+CONFIG_SCHED_CORE                     |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_DEBUG_SG                       |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_LIST_HARDENED                  |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_SCHED_STACK_END_CHECK          |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT|kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_DEFAULT_MMAP_MIN_ADDR          |kconfig| self_protection  |   kspp   |   65536    | OK
+CONFIG_GCC_PLUGIN_STACKLEAK           |kconfig| self_protection  |   kspp   |     y      | FAIL: is not found
+CONFIG_STACKLEAK_METRICS              |kconfig| self_protection  |   kspp   | is not set | FAIL: CONFIG_GCC_PLUGIN_STACKLEAK is not "y"
+CONFIG_STACKLEAK_RUNTIME_DISABLE      |kconfig| self_protection  |   kspp   | is not set | FAIL: CONFIG_GCC_PLUGIN_STACKLEAK is not "y"
+CONFIG_PAGE_TABLE_CHECK               |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_PAGE_TABLE_CHECK_ENFORCED      |kconfig| self_protection  |   kspp   |     y      | FAIL: is not found
+CONFIG_HW_RANDOM_TPM                  |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_CFI_CLANG                      |kconfig| self_protection  |   kspp   |     y      | FAIL: CONFIG_CC_IS_CLANG is not "y"
+CONFIG_CFI_PERMISSIVE                 |kconfig| self_protection  |   kspp   | is not set | FAIL: CONFIG_CC_IS_CLANG is not "y"
+CONFIG_IOMMU_DEFAULT_DMA_STRICT       |kconfig| self_protection  |   kspp   |     y      | FAIL: "is not set"
+CONFIG_INTEL_IOMMU_DEFAULT_ON         |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_MITIGATION_SLS                 |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_INTEL_IOMMU_SVM                |kconfig| self_protection  |   kspp   |     y      | OK
+CONFIG_AMD_IOMMU_V2                   |kconfig| self_protection  |   kspp   |     y      | OK: version >= (6, 7, 0)
+CONFIG_CFI_AUTO_DEFAULT               |kconfig| self_protection  |a13xp0p0v | is not set | FAIL: CONFIG_CFI_AUTO_DEFAULT is not present
+CONFIG_SECURITY                       |kconfig| security_policy  |defconfig |     y      | OK
+CONFIG_SECURITY_YAMA                  |kconfig| security_policy  |   kspp   |     y      | OK
+CONFIG_LSM                            |kconfig| security_policy  |   kspp   |   *yama*   | OK: in "landlock,lockdown,yama,integrity,apparmor"
+CONFIG_SECURITY_LANDLOCK              |kconfig| security_policy  |   kspp   |     y      | OK
+CONFIG_LSM                            |kconfig| security_policy  |   kspp   | *landlock* | OK: in "landlock,lockdown,yama,integrity,apparmor"
+CONFIG_SECURITY_SELINUX_DISABLE       |kconfig| security_policy  |   kspp   | is not set | OK: is not found
+CONFIG_SECURITY_SELINUX_BOOTPARAM     |kconfig| security_policy  |   kspp   | is not set | FAIL: "y"
+CONFIG_SECURITY_SELINUX_DEVELOP       |kconfig| security_policy  |   kspp   | is not set | FAIL: "y"
+CONFIG_SECURITY_WRITABLE_HOOKS        |kconfig| security_policy  |   kspp   | is not set | OK: is not found
+CONFIG_SECURITY_SELINUX_DEBUG         |kconfig| security_policy  |   kspp   | is not set | OK
+CONFIG_SECURITY_SELINUX               |kconfig| security_policy  |a13xp0p0v |     y      | OK
+CONFIG_LSM                            |kconfig| security_policy  |a13xp0p0v | *selinux*  | OK: "apparmor" is in CONFIG_LSM
+CONFIG_SECCOMP                        |kconfig|cut_attack_surface|defconfig |     y      | OK
+CONFIG_SECCOMP_FILTER                 |kconfig|cut_attack_surface|defconfig |     y      | OK
+CONFIG_BPF_UNPRIV_DEFAULT_OFF         |kconfig|cut_attack_surface|defconfig |     y      | OK
+CONFIG_STRICT_DEVMEM                  |kconfig|cut_attack_surface|defconfig |     y      | OK
+CONFIG_X86_INTEL_TSX_MODE_OFF         |kconfig|cut_attack_surface|defconfig |     y      | OK
+CONFIG_SECURITY_DMESG_RESTRICT        |kconfig|cut_attack_surface|   kspp   |     y      | OK
+CONFIG_ACPI_CUSTOM_METHOD             |kconfig|cut_attack_surface|   kspp   | is not set | OK: is not found
+CONFIG_COMPAT_BRK                     |kconfig|cut_attack_surface|   kspp   | is not set | OK
+CONFIG_DEVKMEM                        |kconfig|cut_attack_surface|   kspp   | is not set | OK: is not found
+CONFIG_BINFMT_MISC                    |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "m"
+CONFIG_INET_DIAG                      |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "m"
+CONFIG_KEXEC                          |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_PROC_KCORE                     |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_LEGACY_PTYS                    |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_HIBERNATION                    |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_COMPAT                         |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_IA32_EMULATION                 |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_X86_X32                        |kconfig|cut_attack_surface|   kspp   | is not set | OK: is not found
+CONFIG_X86_X32_ABI                    |kconfig|cut_attack_surface|   kspp   | is not set | OK
+CONFIG_MODIFY_LDT_SYSCALL             |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_OABI_COMPAT                    |kconfig|cut_attack_surface|   kspp   | is not set | OK: is not found
+CONFIG_X86_MSR                        |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "m"
+CONFIG_LEGACY_TIOCSTI                 |kconfig|cut_attack_surface|   kspp   | is not set | OK
+CONFIG_MODULE_FORCE_LOAD              |kconfig|cut_attack_surface|   kspp   | is not set | OK
+CONFIG_MODULES                        |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_DEVMEM                         |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_IO_STRICT_DEVMEM               |kconfig|cut_attack_surface|   kspp   |     y      | FAIL: "is not set"
+CONFIG_LDISC_AUTOLOAD                 |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_X86_VSYSCALL_EMULATION         |kconfig|cut_attack_surface|   kspp   | is not set | FAIL: "y"
+CONFIG_COMPAT_VDSO                    |kconfig|cut_attack_surface|   kspp   | is not set | OK
+CONFIG_DRM_LEGACY                     |kconfig|cut_attack_surface|maintainer| is not set | OK: is not found
+CONFIG_FB                             |kconfig|cut_attack_surface|maintainer| is not set | FAIL: "y"
+CONFIG_VT                             |kconfig|cut_attack_surface|maintainer| is not set | FAIL: "y"
+CONFIG_BLK_DEV_FD                     |kconfig|cut_attack_surface|maintainer| is not set | OK
+CONFIG_BLK_DEV_FD_RAWCMD              |kconfig|cut_attack_surface|maintainer| is not set | OK: is not found
+CONFIG_NOUVEAU_LEGACY_CTX_SUPPORT     |kconfig|cut_attack_surface|maintainer| is not set | OK: is not found
+CONFIG_N_GSM                          |kconfig|cut_attack_surface|maintainer| is not set | FAIL: "m"
+CONFIG_ZSMALLOC_STAT                  |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_DEBUG_KMEMLEAK                 |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_BINFMT_AOUT                    |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_KPROBE_EVENTS                  |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_UPROBE_EVENTS                  |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_GENERIC_TRACER                 |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_FUNCTION_TRACER                |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_STACK_TRACER                   |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_HIST_TRIGGERS                  |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_BLK_DEV_IO_TRACE               |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_PROC_VMCORE                    |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_PROC_PAGE_MONITOR              |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_USELIB                         |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_CHECKPOINT_RESTORE             |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_USERFAULTFD                    |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_HWPOISON_INJECT                |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_MEM_SOFT_DIRTY                 |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_DEVPORT                        |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_DEBUG_FS                       |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_NOTIFIER_ERROR_INJECTION       |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_FAIL_FUTEX                     |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_PUNIT_ATOM_DEBUG               |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_ACPI_CONFIGFS                  |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_EDAC_DEBUG                     |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_DRM_I915_DEBUG                 |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_DVB_C8SECTPFE                  |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_MTD_SLRAM                      |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_MTD_PHRAM                      |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_IO_URING                       |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_KCMP                           |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_RSEQ                           |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_LATENCYTOP                     |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_KCOV                           |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_PROVIDE_OHCI1394_DMA_INIT      |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_SUNRPC_DEBUG                   |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_X86_16BIT                      |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_BLK_DEV_UBLK                   |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_SMB_SERVER                     |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_XFS_ONLINE_SCRUB_STATS         |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_CACHESTAT_SYSCALL              |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_PREEMPTIRQ_TRACEPOINTS         |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_ENABLE_DEFAULT_TRACERS         |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_PROVE_LOCKING                  |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_TEST_DEBUG_VIRTUAL             |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_MPTCP                          |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_TLS                            |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_TIPC                           |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_IP_SCTP                        |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "m"
+CONFIG_KGDB                           |kconfig|cut_attack_surface|  grsec   | is not set | FAIL: "y"
+CONFIG_PTDUMP_DEBUGFS                 |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_X86_PTDUMP                     |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_DEBUG_CLOSURES                 |kconfig|cut_attack_surface|  grsec   | is not set | OK
+CONFIG_BCACHE_CLOSURES_DEBUG          |kconfig|cut_attack_surface|  grsec   | is not set | OK: is not found
+CONFIG_STAGING                        |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_KSM                            |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_KALLSYMS                       |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_KEXEC_FILE                     |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_CRASH_DUMP                     |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_USER_NS                        |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_X86_CPUID                      |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "m"
+CONFIG_X86_IOPL_IOPERM                |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_ACPI_TABLE_UPGRADE             |kconfig|cut_attack_surface|  clipos  | is not set | OK
+CONFIG_EFI_CUSTOM_SSDT_OVERLAYS       |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_AIO                            |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_MAGIC_SYSRQ                    |kconfig|cut_attack_surface|  clipos  | is not set | FAIL: "y"
+CONFIG_MAGIC_SYSRQ_SERIAL             |kconfig|cut_attack_surface|grapheneos| is not set | FAIL: "y"
+CONFIG_EFI_TEST                       |kconfig|cut_attack_surface| lockdown | is not set | FAIL: "m"
+CONFIG_MMIOTRACE_TEST                 |kconfig|cut_attack_surface| lockdown | is not set | OK
+CONFIG_KPROBES                        |kconfig|cut_attack_surface| lockdown | is not set | FAIL: "y"
+CONFIG_BPF_SYSCALL                    |kconfig|cut_attack_surface| lockdown | is not set | FAIL: "y"
+CONFIG_MMIOTRACE                      |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "y"
+CONFIG_LIVEPATCH                      |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "y"
+CONFIG_IP_DCCP                        |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "m"
+CONFIG_FTRACE                         |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "y"
+CONFIG_VIDEO_VIVID                    |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "m"
+CONFIG_INPUT_EVBUG                    |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "m"
+CONFIG_CORESIGHT                      |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK: is not found
+CONFIG_XFS_SUPPORT_V4                 |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "y"
+CONFIG_BLK_DEV_WRITE_MOUNTED          |kconfig|cut_attack_surface|a13xp0p0v | is not set | FAIL: "y"
+CONFIG_FAULT_INJECTION                |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK
+CONFIG_ARM_PTDUMP_DEBUGFS             |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK: is not found
+CONFIG_ARM_PTDUMP                     |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK: is not found
+CONFIG_SECCOMP_CACHE_DEBUG            |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK
+CONFIG_LKDTM                          |kconfig|cut_attack_surface|a13xp0p0v | is not set | OK
+CONFIG_TRIM_UNUSED_KSYMS              |kconfig|cut_attack_surface|a13xp0p0v |     y      | FAIL: "is not set"
+CONFIG_COREDUMP                       |kconfig| harden_userspace |  clipos  | is not set | FAIL: "y"
+CONFIG_ARCH_MMAP_RND_BITS             |kconfig| harden_userspace |a13xp0p0v |     32     | OK
+CONFIG_ARCH_MMAP_RND_COMPAT_BITS      |kconfig| harden_userspace |a13xp0p0v |     16     | OK
+CONFIG_X86_USER_SHADOW_STACK          |kconfig| harden_userspace |   kspp   |     y      | OK
+nosmep                                |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nosmap                                |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nokaslr                               |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nopti                                 |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nospectre_v1                          |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nospectre_v2                          |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nospectre_bhb                         |cmdline| self_protection  |defconfig | is not set | OK: is not found
+nospec_store_bypass_disable           |cmdline| self_protection  |defconfig | is not set | OK: is not found
+dis_ucode_ldr                         |cmdline| self_protection  |defconfig | is not set | OK: is not found
+arm64.nobti                           |cmdline| self_protection  |defconfig | is not set | OK: is not found
+arm64.nopauth                         |cmdline| self_protection  |defconfig | is not set | OK: is not found
+arm64.nomte                           |cmdline| self_protection  |defconfig | is not set | OK: is not found
+iommu.passthrough                     |cmdline| self_protection  |defconfig |     0      | OK: CONFIG_IOMMU_DEFAULT_PASSTHROUGH is "is not set"
+rodata                                |cmdline| self_protection  |defconfig |     on     | OK: rodata is not found
+spectre_v2                            |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+spectre_v2_user                       |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+spectre_bhi                           |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+spec_store_bypass_disable             |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+l1tf                                  |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+mds                                   |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+tsx_async_abort                       |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+srbds                                 |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+mmio_stale_data                       |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+retbleed                              |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+spec_rstack_overflow                  |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+gather_data_sampling                  |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+reg_file_data_sampling                |cmdline| self_protection  |defconfig | is not off | FAIL: is off, not found
+slab_merge                            |cmdline| self_protection  |   kspp   | is not set | OK: is not found
+slub_merge                            |cmdline| self_protection  |   kspp   | is not set | OK: is not found
+page_alloc.shuffle                    |cmdline| self_protection  |   kspp   |     1      | FAIL: is not found
+slab_nomerge                          |cmdline| self_protection  |   kspp   | is present | FAIL: is not present
+init_on_alloc                         |cmdline| self_protection  |   kspp   |     1      | OK: CONFIG_INIT_ON_ALLOC_DEFAULT_ON is "y"
+init_on_free                          |cmdline| self_protection  |   kspp   |     1      | FAIL: is not found
+hardened_usercopy                     |cmdline| self_protection  |   kspp   |     1      | OK: CONFIG_HARDENED_USERCOPY is "y"
+slab_common.usercopy_fallback         |cmdline| self_protection  |   kspp   | is not set | OK: is not found
+kfence.sample_interval                |cmdline| self_protection  |   kspp   |    100     | FAIL: is not found
+randomize_kstack_offset               |cmdline| self_protection  |   kspp   |     1      | OK: CONFIG_RANDOMIZE_KSTACK_OFFSET_DEFAULT is "y"
+mitigations                           |cmdline| self_protection  |   kspp   | auto,nosmt | FAIL: is not found
+iommu.strict                          |cmdline| self_protection  |   kspp   |     1      | FAIL: is not found
+pti                                   |cmdline| self_protection  |   kspp   |     on     | FAIL: is not found
+cfi                                   |cmdline| self_protection  |   kspp   |    kcfi    | FAIL: is not found
+iommu                                 |cmdline| self_protection  |  clipos  |   force    | FAIL: is not found
+tsx                                   |cmdline|cut_attack_surface|defconfig |    off     | OK: CONFIG_X86_INTEL_TSX_MODE_OFF is "y"
+nosmt                                 |cmdline|cut_attack_surface|   kspp   | is present | FAIL: is not present
+vsyscall                              |cmdline|cut_attack_surface|   kspp   |    none    | FAIL: is not found
+vdso32                                |cmdline|cut_attack_surface|   kspp   |     0      | OK: CONFIG_COMPAT_VDSO is "is not set"
+debugfs                               |cmdline|cut_attack_surface|  grsec   |    off     | FAIL: is not found
+sysrq_always_enabled                  |cmdline|cut_attack_surface|grapheneos| is not set | OK: is not found
+bdev_allow_write_mounted              |cmdline|cut_attack_surface|a13xp0p0v |     0      | FAIL: is not found
+ia32_emulation                        |cmdline|cut_attack_surface|a13xp0p0v |     0      | FAIL: is not found
+norandmaps                            |cmdline| harden_userspace |defconfig | is not set | OK: is not found
+net.core.bpf_jit_harden               |sysctl | self_protection  |   kspp   |     2      | FAIL: is not found
+kernel.oops_limit                     |sysctl | self_protection  |a13xp0p0v |    100     | FAIL: "10000"
+kernel.warn_limit                     |sysctl | self_protection  |a13xp0p0v |    100     | FAIL: "0"
+vm.mmap_min_addr                      |sysctl | self_protection  |   kspp   |   65536    | OK
+kernel.dmesg_restrict                 |sysctl |cut_attack_surface|   kspp   |     1      | OK
+kernel.perf_event_paranoid            |sysctl |cut_attack_surface|   kspp   |     3      | FAIL: "4"
+dev.tty.ldisc_autoload                |sysctl |cut_attack_surface|   kspp   |     0      | FAIL: "1"
+kernel.kptr_restrict                  |sysctl |cut_attack_surface|   kspp   |     2      | FAIL: "1"
+dev.tty.legacy_tiocsti                |sysctl |cut_attack_surface|   kspp   |     0      | OK
+user.max_user_namespaces              |sysctl |cut_attack_surface|   kspp   |     0      | FAIL: "63936"
+kernel.kexec_load_disabled            |sysctl |cut_attack_surface|   kspp   |     1      | FAIL: "0"
+kernel.unprivileged_bpf_disabled      |sysctl |cut_attack_surface|   kspp   |     1      | FAIL: "2"
+vm.unprivileged_userfaultfd           |sysctl |cut_attack_surface|   kspp   |     0      | OK
+kernel.modules_disabled               |sysctl |cut_attack_surface|   kspp   |     1      | FAIL: "0"
+kernel.io_uring_disabled              |sysctl |cut_attack_surface|  grsec   |     2      | FAIL: "0"
+kernel.sysrq                          |sysctl |cut_attack_surface|a13xp0p0v |     0      | FAIL: "176"
+fs.protected_symlinks                 |sysctl | harden_userspace |   kspp   |     1      | OK
+fs.protected_hardlinks                |sysctl | harden_userspace |   kspp   |     1      | OK
+fs.protected_fifos                    |sysctl | harden_userspace |   kspp   |     2      | FAIL: "1"
+fs.protected_regular                  |sysctl | harden_userspace |   kspp   |     2      | OK
+fs.suid_dumpable                      |sysctl | harden_userspace |   kspp   |     0      | FAIL: "2"
+kernel.randomize_va_space             |sysctl | harden_userspace |   kspp   |     2      | OK
+kernel.yama.ptrace_scope              |sysctl | harden_userspace |   kspp   |     3      | FAIL: "1"
+vm.mmap_rnd_bits                      |sysctl | harden_userspace |a13xp0p0v |     32     | FAIL: is not found
+vm.mmap_rnd_compat_bits               |sysctl | harden_userspace |a13xp0p0v |     16     | FAIL: is not found
 
 [+] Config check is finished: 'OK' - 155 / 'FAIL' - 147
 ```

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -174,7 +174,7 @@ def print_checklist(mode: StrOrNone, checklist: List[ChecklistObjType], with_res
     if with_results:
         sep_line_len += 30
     print('=' * sep_line_len)
-    print(f'{"option_name":^40}|{"type":^7}|{"desired_val":^12}|{"decision":^10}|{"reason":^18}', end='')
+    print(f'{"option_name":^40}|{"type":^7}|{"reason":^18}|{"decision":^10}|{"desired_val":^12}', end='')
     if with_results:
         print('| check_result', end='')
     print()

--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -174,7 +174,7 @@ def print_checklist(mode: StrOrNone, checklist: List[ChecklistObjType], with_res
     if with_results:
         sep_line_len += 30
     print('=' * sep_line_len)
-    print(f'{"option_name":^40}|{"type":^7}|{"reason":^18}|{"decision":^10}|{"desired_val":^12}', end='')
+    print(f'{"option_name":^38}|{"type":^7}|{"reason":^18}|{"decision":^10}|{"desired_val":^12}', end='')
     if with_results:
         print('| check_result', end='')
     print()

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -129,7 +129,7 @@ class OptCheck:
             self.result = f'FAIL: "{self.state}"'
 
     def table_print(self, _mode: StrOrNone, with_results: bool) -> None:
-        print(f'{self.name:<40}|{self.opt_type:^7}|{self.reason:^18}|{self.decision:^10}|{self.expected:^12}', end='')
+        print(f'{self.name:<38}|{self.opt_type:^7}|{self.reason:^18}|{self.decision:^10}|{self.expected:^12}', end='')
         if with_results:
             print(f'| {colorize_result(self.result)}', end='')
 

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -129,7 +129,7 @@ class OptCheck:
             self.result = f'FAIL: "{self.state}"'
 
     def table_print(self, _mode: StrOrNone, with_results: bool) -> None:
-        print(f'{self.name:<40}|{self.opt_type:^7}|{self.expected:^12}|{self.decision:^10}|{self.reason:^18}', end='')
+        print(f'{self.name:<40}|{self.opt_type:^7}|{self.reason:^18}|{self.decision:^10}|{self.expected:^12}', end='')
         if with_results:
             print(f'| {colorize_result(self.result)}', end='')
 
@@ -138,9 +138,9 @@ class OptCheck:
         dump = {
             'option_name': self.name,
             'type': self.opt_type,
-            'desired_val': self.expected,
-            'decision': self.decision,
             'reason': self.reason,
+            'decision': self.decision,
+            'desired_val': self.expected,
         } # type: Dict[str, StrOrBool]
         if with_results:
             assert(self.result), f'unexpected empty result in {self.name}'

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -475,9 +475,9 @@ class TestEngine(unittest.TestCase):
                 stdout_result,
                 [
 '\
-CONFIG_NAME_1                           |kconfig|     reason_1     |decision_1| expected_1 | OK: name_2 is "expected_2"\
-CONFIG_NAME_4                           |kconfig|     reason_4     |decision_4| expected_4 | FAIL: name_5 is not "expected_5"\
-CONFIG_NAME_7                           |kconfig|     reason_7     |decision_7| expected_7 | FAIL: version < (42, 43, 44)\
+CONFIG_NAME_1                         |kconfig|     reason_1     |decision_1| expected_1 | OK: name_2 is "expected_2"\
+CONFIG_NAME_4                         |kconfig|     reason_4     |decision_4| expected_4 | FAIL: name_5 is not "expected_5"\
+CONFIG_NAME_7                         |kconfig|     reason_7     |decision_7| expected_7 | FAIL: version < (42, 43, 44)\
 '               ]
         )
 
@@ -488,19 +488,19 @@ CONFIG_NAME_7                           |kconfig|     reason_7     |decision_7| 
                 [
 '\
     <<< OR >>>                                                                             | OK: name_2 is "expected_2"\n\
-CONFIG_NAME_1                           |kconfig|     reason_1     |decision_1| expected_1 | FAIL: "UNexpected_1"\n\
-name_2                                  |cmdline|     reason_2     |decision_2| expected_2 | OK\n\
-name_3                                  |sysctl |     reason_3     |decision_3| expected_3 | None\
+CONFIG_NAME_1                         |kconfig|     reason_1     |decision_1| expected_1 | FAIL: "UNexpected_1"\n\
+name_2                                |cmdline|     reason_2     |decision_2| expected_2 | OK\n\
+name_3                                |sysctl |     reason_3     |decision_3| expected_3 | None\
 '\
 '\
     <<< AND >>>                                                                            | FAIL: name_5 is not "expected_5"\n\
-CONFIG_NAME_4                           |kconfig|     reason_4     |decision_4| expected_4 | None\n\
-name_5                                  |cmdline|     reason_5     |decision_5| expected_5 | FAIL: "UNexpected_5"\n\
-name_6                                  |sysctl |     reason_6     |decision_6| expected_6 | OK\
+CONFIG_NAME_4                         |kconfig|     reason_4     |decision_4| expected_4 | None\n\
+name_5                                |cmdline|     reason_5     |decision_5| expected_5 | FAIL: "UNexpected_5"\n\
+name_6                                |sysctl |     reason_6     |decision_6| expected_6 | OK\
 '
 '\
     <<< AND >>>                                                                            | FAIL: version < (42, 43, 44)\n\
-CONFIG_NAME_7                           |kconfig|     reason_7     |decision_7| expected_7 | None\n\
+CONFIG_NAME_7                         |kconfig|     reason_7     |decision_7| expected_7 | None\n\
 kernel version >= (42, 43, 44)                                                             | FAIL: version < (42, 43, 44)\
 '               ]
         )

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -153,19 +153,19 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_2', 'type': 'kconfig', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'desired_val': 'is not set', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'OK: is not found', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'desired_val': 'is present', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'OK: is present', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_6', 'type': 'kconfig', 'desired_val': 'is present', 'decision': 'decision_6', 'reason': 'reason_6', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'desired_val': 'is not off', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'OK: is not off, "really_not_off"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_8', 'type': 'kconfig', 'desired_val': 'is not off', 'decision': 'decision_8', 'reason': 'reason_8', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'desired_val': 'is not off', 'decision': 'decision_9', 'reason': 'reason_9', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'desired_val': 'is not off', 'decision': 'decision_10', 'reason': 'reason_10', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'desired_val': '*expected_11*', 'decision': 'decision_11', 'reason': 'reason_11', 'check_result': 'OK: in "expected_11,something,UNexpected2"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'desired_val': '*expected_12*', 'decision': 'decision_12', 'reason': 'reason_12', 'check_result': 'FAIL: not in "UNexpected_12,something"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'desired_val': '*expected_13*', 'decision': 'decision_13', 'reason': 'reason_13', 'check_result': 'FAIL: is not found', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_2', 'type': 'kconfig', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_6', 'type': 'kconfig', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, "really_not_off"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_8', 'type': 'kconfig', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': '*expected_11*', 'check_result': 'OK: in "expected_11,something,UNexpected2"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': '*expected_12*', 'check_result': 'FAIL: not in "UNexpected_12,something"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}]
         )
 
     def test_simple_cmdline(self) -> None:
@@ -199,16 +199,16 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'name_1', 'type': 'cmdline', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_2', 'type': 'cmdline', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
-                 {'option_name': 'name_3', 'type': 'cmdline', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
-                 {'option_name': 'name_4', 'type': 'cmdline', 'desired_val': 'is not set', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'OK: is not found', 'check_result_bool': True},
-                 {'option_name': 'name_5', 'type': 'cmdline', 'desired_val': 'is present', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'OK: is present', 'check_result_bool': True},
-                 {'option_name': 'name_6', 'type': 'cmdline', 'desired_val': 'is present', 'decision': 'decision_6', 'reason': 'reason_6', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'name_7', 'type': 'cmdline', 'desired_val': 'is not off', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
-                 {'option_name': 'name_8', 'type': 'cmdline', 'desired_val': 'is not off', 'decision': 'decision_8', 'reason': 'reason_8', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'name_9', 'type': 'cmdline', 'desired_val': 'is not off', 'decision': 'decision_9', 'reason': 'reason_9', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
-                 {'option_name': 'name_10', 'type': 'cmdline', 'desired_val': 'is not off', 'decision': 'decision_10', 'reason': 'reason_10', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}]
+                [{'option_name': 'name_1', 'type': 'cmdline', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_2', 'type': 'cmdline', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
+                 {'option_name': 'name_3', 'type': 'cmdline', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
+                 {'option_name': 'name_4', 'type': 'cmdline', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
+                 {'option_name': 'name_5', 'type': 'cmdline', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
+                 {'option_name': 'name_6', 'type': 'cmdline', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
+                 {'option_name': 'name_7', 'type': 'cmdline', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
+                 {'option_name': 'name_8', 'type': 'cmdline', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
+                 {'option_name': 'name_9', 'type': 'cmdline', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'name_10', 'type': 'cmdline', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}]
         )
 
     def test_simple_sysctl(self) -> None:
@@ -242,16 +242,16 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'name_1', 'type': 'sysctl', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_2', 'type': 'sysctl', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
-                 {'option_name': 'name_3', 'type': 'sysctl', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
-                 {'option_name': 'name_4', 'type': 'sysctl', 'desired_val': 'is not set', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'OK: is not found', 'check_result_bool': True},
-                 {'option_name': 'name_5', 'type': 'sysctl', 'desired_val': 'is present', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'OK: is present', 'check_result_bool': True},
-                 {'option_name': 'name_6', 'type': 'sysctl', 'desired_val': 'is present', 'decision': 'decision_6', 'reason': 'reason_6', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'name_7', 'type': 'sysctl', 'desired_val': 'is not off', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
-                 {'option_name': 'name_8', 'type': 'sysctl', 'desired_val': 'is not off', 'decision': 'decision_8', 'reason': 'reason_8', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'name_9', 'type': 'sysctl', 'desired_val': 'is not off', 'decision': 'decision_9', 'reason': 'reason_9', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
-                 {'option_name': 'name_10', 'type': 'sysctl', 'desired_val': 'is not off', 'decision': 'decision_10', 'reason': 'reason_10', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}]
+                [{'option_name': 'name_1', 'type': 'sysctl', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_2', 'type': 'sysctl', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: "UNexpected_2"', 'check_result_bool': False},
+                 {'option_name': 'name_3', 'type': 'sysctl', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
+                 {'option_name': 'name_4', 'type': 'sysctl', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
+                 {'option_name': 'name_5', 'type': 'sysctl', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
+                 {'option_name': 'name_6', 'type': 'sysctl', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
+                 {'option_name': 'name_7', 'type': 'sysctl', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
+                 {'option_name': 'name_8', 'type': 'sysctl', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
+                 {'option_name': 'name_9', 'type': 'sysctl', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'name_10', 'type': 'sysctl', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}]
         )
 
     def test_complex_or(self) -> None:
@@ -289,12 +289,12 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'OK: CONFIG_NAME_4 is "expected_4"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'desired_val': 'expected_5', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'FAIL: "UNexpected_5"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'desired_val': 'expected_7', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'OK: CONFIG_NAME_8 is not found', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'desired_val': 'expected_9', 'decision': 'decision_9', 'reason': 'reason_9', 'check_result': 'OK: CONFIG_NAME_10 is present', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'desired_val': 'expected_11', 'decision': 'decision_11', 'reason': 'reason_11', 'check_result': 'OK: CONFIG_NAME_12 is not off', 'check_result_bool': True}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'OK: CONFIG_NAME_4 is "expected_4"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'expected_5', 'check_result': 'FAIL: "UNexpected_5"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'OK: CONFIG_NAME_8 is not found', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'OK: CONFIG_NAME_10 is present', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'OK: CONFIG_NAME_12 is not off', 'check_result_bool': True}]
         )
 
     def test_complex_and(self) -> None:
@@ -334,12 +334,12 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: CONFIG_NAME_4 is not "expected_4"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'desired_val': 'expected_5', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'FAIL: "UNexpected_5"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'desired_val': 'expected_7', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'FAIL: CONFIG_NAME_8 is not present', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'desired_val': 'expected_9', 'decision': 'decision_9', 'reason': 'reason_9', 'check_result': 'FAIL: CONFIG_NAME_10 is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'desired_val': 'expected_11', 'decision': 'decision_11', 'reason': 'reason_11', 'check_result': 'FAIL: CONFIG_NAME_12 is off, not found', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: CONFIG_NAME_4 is not "expected_4"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'expected_5', 'check_result': 'FAIL: "UNexpected_5"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'FAIL: CONFIG_NAME_8 is not present', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'FAIL: CONFIG_NAME_10 is off', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'FAIL: CONFIG_NAME_12 is off, not found', 'check_result_bool': False}]
         )
 
     def test_complex_nested(self) -> None:
@@ -381,10 +381,10 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'desired_val': 'expected_4', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'FAIL: CONFIG_NAME_5 is not "expected_5"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'desired_val': 'expected_7', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'OK: CONFIG_NAME_8 is "expected_8"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'desired_val': 'expected_10', 'decision': 'decision_10', 'reason': 'reason_10', 'check_result': 'FAIL: "UNexpected_10"', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'expected_4', 'check_result': 'FAIL: CONFIG_NAME_5 is not "expected_5"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'OK: CONFIG_NAME_8 is "expected_8"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'expected_10', 'check_result': 'FAIL: "UNexpected_10"', 'check_result_bool': False}]
         )
 
     def test_version(self) -> None:
@@ -420,12 +420,12 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK: version >= (41, 101, 0)', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_2', 'type': 'kconfig', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: version < (43, 1, 0)', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'OK: version >= (42, 42, 101)', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'desired_val': 'expected_4', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'FAIL: version < (42, 44, 1)', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'desired_val': 'expected_5', 'decision': 'decision_5', 'reason': 'reason_5', 'check_result': 'OK: version >= (42, 43, 44)', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_6', 'type': 'kconfig', 'desired_val': 'expected_6', 'decision': 'decision_6', 'reason': 'reason_6', 'check_result': 'FAIL: version < (42, 43, 45)', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK: version >= (41, 101, 0)', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_2', 'type': 'kconfig', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: version < (43, 1, 0)', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'OK: version >= (42, 42, 101)', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'expected_4', 'check_result': 'FAIL: version < (42, 44, 1)', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'expected_5', 'check_result': 'OK: version >= (42, 43, 44)', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_6', 'type': 'kconfig', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'expected_6', 'check_result': 'FAIL: version < (42, 43, 45)', 'check_result_bool': False}]
         )
 
     def test_stdout(self) -> None:
@@ -464,9 +464,9 @@ class TestEngine(unittest.TestCase):
         self.get_engine_result(config_checklist, json_result, 'json')
         self.assertEqual(
                 json_result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK: name_2 is "expected_2"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'desired_val': 'expected_4', 'decision': 'decision_4', 'reason': 'reason_4', 'check_result': 'FAIL: name_5 is not "expected_5"', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'desired_val': 'expected_7', 'decision': 'decision_7', 'reason': 'reason_7', 'check_result': 'FAIL: version < (42, 43, 44)', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'OK: name_2 is "expected_2"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'expected_4', 'check_result': 'FAIL: name_5 is not "expected_5"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'FAIL: version < (42, 43, 44)', 'check_result_bool': False}]
         )
 
         stdout_result = [] # type: ResultType
@@ -475,9 +475,9 @@ class TestEngine(unittest.TestCase):
                 stdout_result,
                 [
 '\
-CONFIG_NAME_1                           |kconfig| expected_1 |decision_1|     reason_1     | OK: name_2 is "expected_2"\
-CONFIG_NAME_4                           |kconfig| expected_4 |decision_4|     reason_4     | FAIL: name_5 is not "expected_5"\
-CONFIG_NAME_7                           |kconfig| expected_7 |decision_7|     reason_7     | FAIL: version < (42, 43, 44)\
+CONFIG_NAME_1                           |kconfig|     reason_1     |decision_1| expected_1 | OK: name_2 is "expected_2"\
+CONFIG_NAME_4                           |kconfig|     reason_4     |decision_4| expected_4 | FAIL: name_5 is not "expected_5"\
+CONFIG_NAME_7                           |kconfig|     reason_7     |decision_7| expected_7 | FAIL: version < (42, 43, 44)\
 '               ]
         )
 
@@ -488,19 +488,19 @@ CONFIG_NAME_7                           |kconfig| expected_7 |decision_7|     re
                 [
 '\
     <<< OR >>>                                                                             | OK: name_2 is "expected_2"\n\
-CONFIG_NAME_1                           |kconfig| expected_1 |decision_1|     reason_1     | FAIL: "UNexpected_1"\n\
-name_2                                  |cmdline| expected_2 |decision_2|     reason_2     | OK\n\
-name_3                                  |sysctl | expected_3 |decision_3|     reason_3     | None\
+CONFIG_NAME_1                           |kconfig|     reason_1     |decision_1| expected_1 | FAIL: "UNexpected_1"\n\
+name_2                                  |cmdline|     reason_2     |decision_2| expected_2 | OK\n\
+name_3                                  |sysctl |     reason_3     |decision_3| expected_3 | None\
 '\
 '\
     <<< AND >>>                                                                            | FAIL: name_5 is not "expected_5"\n\
-CONFIG_NAME_4                           |kconfig| expected_4 |decision_4|     reason_4     | None\n\
-name_5                                  |cmdline| expected_5 |decision_5|     reason_5     | FAIL: "UNexpected_5"\n\
-name_6                                  |sysctl | expected_6 |decision_6|     reason_6     | OK\
+CONFIG_NAME_4                           |kconfig|     reason_4     |decision_4| expected_4 | None\n\
+name_5                                  |cmdline|     reason_5     |decision_5| expected_5 | FAIL: "UNexpected_5"\n\
+name_6                                  |sysctl |     reason_6     |decision_6| expected_6 | OK\
 '
 '\
     <<< AND >>>                                                                            | FAIL: version < (42, 43, 44)\n\
-CONFIG_NAME_7                           |kconfig| expected_7 |decision_7|     reason_7     | None\n\
+CONFIG_NAME_7                           |kconfig|     reason_7     |decision_7| expected_7 | None\n\
 kernel version >= (42, 43, 44)                                                             | FAIL: version < (42, 43, 44)\
 '               ]
         )
@@ -532,9 +532,9 @@ kernel version >= (42, 43, 44)                                                  
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'FAIL: "expected_1_new"', 'check_result_bool': False},
-                 {'option_name': 'name_2', 'type': 'cmdline', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: "expected_2_new"', 'check_result_bool': False},
-                 {'option_name': 'name_3', 'type': 'sysctl', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1', 'check_result': 'FAIL: "expected_1_new"', 'check_result_bool': False},
+                 {'option_name': 'name_2', 'type': 'cmdline', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: "expected_2_new"', 'check_result_bool': False},
+                 {'option_name': 'name_3', 'type': 'sysctl', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
         )
 
         # 7. override expected value and perform the checks again
@@ -546,9 +546,9 @@ kernel version >= (42, 43, 44)                                                  
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1_new', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_2', 'type': 'cmdline', 'desired_val': 'expected_2', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'FAIL: "expected_2_new"', 'check_result_bool': False},
-                 {'option_name': 'name_3', 'type': 'sysctl', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1_new', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_2', 'type': 'cmdline', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2', 'check_result': 'FAIL: "expected_2_new"', 'check_result_bool': False},
+                 {'option_name': 'name_3', 'type': 'sysctl', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
         )
 
         # 9. override expected value and perform the checks again
@@ -560,9 +560,9 @@ kernel version >= (42, 43, 44)                                                  
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1_new', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_2', 'type': 'cmdline', 'desired_val': 'expected_2_new', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_3', 'type': 'sysctl', 'desired_val': 'expected_3', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1_new', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_2', 'type': 'cmdline', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2_new', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_3', 'type': 'sysctl', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: "expected_3_new"', 'check_result_bool': False}]
         )
 
         # 11. override expected value and perform the checks again
@@ -574,9 +574,9 @@ kernel version >= (42, 43, 44)                                                  
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
                 result,
-                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'desired_val': 'expected_1_new', 'decision': 'decision_1', 'reason': 'reason_1', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_2', 'type': 'cmdline', 'desired_val': 'expected_2_new', 'decision': 'decision_2', 'reason': 'reason_2', 'check_result': 'OK', 'check_result_bool': True},
-                 {'option_name': 'name_3', 'type': 'sysctl', 'desired_val': 'expected_3_new', 'decision': 'decision_3', 'reason': 'reason_3', 'check_result': 'OK', 'check_result_bool': True}]
+                [{'option_name': 'CONFIG_NAME_1', 'type': 'kconfig', 'reason': 'reason_1', 'decision': 'decision_1', 'desired_val': 'expected_1_new', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_2', 'type': 'cmdline', 'reason': 'reason_2', 'decision': 'decision_2', 'desired_val': 'expected_2_new', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_3', 'type': 'sysctl', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3_new', 'check_result': 'OK', 'check_result_bool': True}]
         )
 
     def test_print_unknown_options_simple(self) -> None:


### PR DESCRIPTION
Hi, I think it's a good idea to reorder the `reason` and `desired_val` tables, because `desired_val` is mostly unpredictable and there can be really long option names, for exaple cmdline parameter `lockdown=confidentiality` or `efi=disable_early_pci_dma` would tear up the output table like this:

![image](https://github.com/user-attachments/assets/9b89a120-6924-4156-b494-7f4089fec348)

After reordering the tables it would look a bit better:

![image](https://github.com/user-attachments/assets/def87443-4b79-4854-af21-c859a8fccdb1)

 By the way, having the desired value close to the check result seems a bit more convenient :)
 
 I hope you will find this addition as a great one, waiting for your review!