### PR TITLE
Extend perf_event_paranoid comment

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -824,7 +824,10 @@ def add_sysctl_checks(l: List[ChecklistObjType], arch: StrOrNone) -> None:
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')]
-          # depends on a custom patch, see https://lwn.net/Articles/696216/
+          # Value '3' behaves identically to '2' without custom hardening patches.
+          # Good detection method is to check for the presence of SECURITY_PERF_EVENTS_RESTRICT kconfig,
+          # mostly relevant for Debian-based distributions.
+          # See https://lkml.org/lkml/2016/1/11/587 and https://lwn.net/Articles/696216/
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -824,10 +824,10 @@ def add_sysctl_checks(l: List[ChecklistObjType], arch: StrOrNone) -> None:
 
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.perf_event_paranoid', '3')]
-          # Value '3' behaves identically to '2' without custom hardening patches.
-          # Good detection method is to check for the presence of SECURITY_PERF_EVENTS_RESTRICT kconfig,
-          # mostly relevant for Debian-based distributions.
-          # See https://lkml.org/lkml/2016/1/11/587 and https://lwn.net/Articles/696216/
+          # Without the custom patch that adds CONFIG_SECURITY_PERF_EVENTS_RESTRICT,
+          # the value '3' has a similar effect to the value '2'. For more information, see:
+          #  - https://lkml.org/lkml/2016/1/11/587
+          #  - https://lwn.net/Articles/696216/
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.ldisc_autoload', '0')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.kptr_restrict', '2')]
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'dev.tty.legacy_tiocsti', '0')]


### PR DESCRIPTION
Hi, looked into the parameter `perf_event_paranoid` and it seems that a value of 2 behaves like 3 in the vast majority of cases. 

Based on https://github.com/a13xp0p0v/kernel-hardening-checker/tree/master/kernel_hardening_checker/config_files/distros and CONFIG_SECURITY_PERF_EVENTS_RESTRICT (see https://lkml.org/lkml/2016/1/11/587) kconfig presence: the unique value 3 is common mostle for Debian family.

So, I think it is better to make more detailed comment