### PR TITLE
Add ZERO_CALL_USED_REGS for side channel mitigation instead of CFI

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -173,6 +173,7 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
     l += [kfence_is_set]
     l += [AND(KconfigCheck('self_protection', 'kspp', 'KFENCE_SAMPLE_INTERVAL', '100'),
               kfence_is_set)]
+    l += [KconfigCheck('self_protection', 'kspp', 'ZERO_CALL_USED_REGS', 'y')]
     randstruct_is_set = OR(KconfigCheck('self_protection', 'kspp', 'RANDSTRUCT_FULL', 'y'),
                            KconfigCheck('self_protection', 'kspp', 'GCC_PLUGIN_RANDSTRUCT', 'y'))
     l += [randstruct_is_set]


### PR DESCRIPTION
This option was removed because it's not worth for ROP mitigation, but it's still can be part of side channel mitigation to those doesn't have hardware mitigation.

Reference:
https://www.amd.com/content/dam/amd/en/documents/resources/technical-guidance-for-mitigating-branch-type-confusion.pdf https://bughunters.google.com/blog/6243730100977664/exploiting-retbleed-in-the-real-world