### PR TITLE
`/proc/<pid>/mem` hardenings

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -527,6 +527,7 @@ def add_kconfig_checks(l: List[ChecklistObjType], arch: str) -> None:
     l += [OR(KconfigCheck('harden_userspace', 'a13xp0p0v', 'ARCH_MMAP_RND_COMPAT_BITS', 'MAX'),
              KconfigCheck('cut_attack_surface', 'kspp', 'COMPAT', 'is not set'))]
              # 'MAX' value is refined using ARCH_MMAP_RND_COMPAT_BITS_MAX
+    l += [KconfigCheck('harden_userspace', 'a13xp0p0v', 'PROC_MEM_NO_FORCE', 'y')]
     if arch == 'X86_64':
         l += [KconfigCheck('harden_userspace', 'kspp', 'X86_USER_SHADOW_STACK', 'y')]
 
@@ -760,6 +761,9 @@ def add_cmdline_checks(l: List[ChecklistObjType], arch: str) -> None:
 
     # 'harden_userspace'
     l += [CmdlineCheck('harden_userspace', 'defconfig', 'norandmaps', 'is not set')]
+    l += [OR(CmdlineCheck('harden_userspace', 'a13xp0p0v', 'proc_mem.force_override', 'never'),
+             AND(KconfigCheck('harden_userspace', 'a13xp0p0v', 'PROC_MEM_NO_FORCE', 'y'),
+                 CmdlineCheck('-', '-', 'proc_mem.force_override', 'is not set')))]
 
 
 no_kstrtobool_options = [
@@ -790,7 +794,8 @@ no_kstrtobool_options = [
     'tsx', # see tsx_init() in arch/x86/kernel/cpu/tsx.c
     'lockdown', # see lockdown_param() in security/lockdown/lockdown.c
     'intel_iommu', # see intel_iommu_setup() in drivers/iommu/intel/iommu.c
-    'efi' # see efi_parse_options() in drivers/firmware/efi/libstub/efi-stub-helper.c
+    'efi', # see efi_parse_options() in drivers/firmware/efi/libstub/efi-stub-helper.c
+    'proc_mem.force_override' # see early_proc_mem_force_override() in fs/proc/base.c
 ]
 
 


### PR DESCRIPTION
According to #173 and #170 

**Option 1: Never Allow `FOLL_FORCE` Bypass**
*   **Kconfig:** `CONFIG_PROC_MEM_NO_FORCE=y`
*   **Command-line:** `proc_mem.force_override=never`

This option completely disables the use of the `FOLL_FORCE` flag within the specific function that handles `/proc/<pid>/mem` (see [fs/proc/base.c, line 877](https://elixir.bootlin.com/linux/v6.16.7/source/fs/proc/base.c#L877)). Normally, `FOLL_FORCE` allows writing to a process's memory via `/proc/<pid>/mem` even if the target memory region has protection flags that would typically prevent writing (e.g., read-only memory or even executable functions).

**Option 2: Allow `FOLL_FORCE` Only for Ptrace-Attached Processes**
*   **Kconfig:** `CONFIG_PROC_MEM_FORCE_PTRACE=y`
*   **Command-line:** `proc_mem.force_override=ptrace`

This option permits the use of `FOLL_FORCE` only when a process has legitimately attached to the target process via `ptrace` (as debuggers do).

**Option 3: Always Allow `FOLL_FORCE` Bypass (Default, Least Secure)**
*   **Kconfig:** `CONFIG_PROC_MEM_ALWAYS_FORCE=y`
*   **Command-line:** `proc_mem.force_override=always`
This is the most permissive and least secure setting. It allows any process with the appropriate permissions (typically the same UID/GID) to write to any memory region of another process via `/proc/<pid>/mem`. From a security perspective, if an attacker compromises any process running as a user, they can potentially manipulate any other process owned by same user.

---

#### **Interaction with `kernel.yama.ptrace_scope`**

Initially, I assumed that sysctl `kernel.yama.ptrace_scope` would achieve a similar level of protection, as it restricts access to all `/proc/<pid>/*` files. For instance, the function `proc_map_files_readdir` (see [fs/proc/base.c, line 2421](https://elixir.bootlin.com/linux/v6.16.7/source/fs/proc/base.c#L2421)) checks `ptrace_scope` before allowing a process to list another process's `/proc` entries. This led me to believe that `yama` hardening (which is already recommended) might make additional `proc_mem` hardening useless -- until I conducted further tests.

---

#### **Demonstration with a Minimal PoC**

Consider the following Proof-of-Concept (PoC) program:
```c
#include <stdio.h>
#include <unistd.h>
#include <sys/mman.h>

void target_func() {
    printf("Target\n");
}

int main() {
    int value = 5;
    void *exec_mem = mmap(NULL, 4096, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);

    while(1) {
	    printf("PID: %d\n", getpid());
        printf("Stack: %p\nExec: %p\nText: %p\nValue: %d\n", 
               &value, exec_mem, target_func, value);
        target_func();
        sleep(10);
    }

    return 0;
}
```

**Example 1: `yama.ptrace_scope=0` or `1`**
```
$ ./poc
PID: 1508
Stack: 0x7fff89013e1c
Exec: 0x7fdcf5ab2000
Text: 0x5562071b11c9
Value: 5

...
$ echo '0x2a000000' | xxd -p -r | dd of=/proc/1508/mem bs=1 seek=$((0x7fff89013e1c)) count=4 conv=notrunc
4+0 records in
4+0 records out
4 bytes copied, 0.000316429 s, 12.6 kB/s
# ... similar commands succeed for the exec and text addresses ...
...

PID: 1508
Stack: 0x7fff89013e1c
Exec: 0x7fdcf5ab2000
Text: 0x5562071b11c9
Value: 42
Segmentation fault (core dumped)
```

Without any defenses, an attacker can overwrite even executable memory (text and exec pages), leading to a crash.

**Example 2: `yama.ptrace_scope=2` or `3` (Restrictive)**
```
$ sudo sysctl -w kernel.yama.ptrace_scope=2
kernel.yama.ptrace_scope = 2
$ ./poc
PID: 1508
...

$ echo '0x2a000000' | xxd -p -r | dd of=/proc/584/mem bs=1 seek=$((0x7ffdfb484b1c)) count=4 conv=notrunc
dd: failed to open '/proc/584/mem': Permission denied
```
As expected, `yama` effectively blocks access to other processes' memory. However, a process can still attempt to modify its *own* memory via `/proc/self/mem`:
```
$ echo '0x2a000000' | xxd -p -r | dd of=/proc/self/mem bs=1 seek=$((0x7fff79030120)) count=4 conv=notrunc
dd: error writing '/proc/self/mem': Input/output error
1+0 records in
0+0 records out
0 bytes copied, 0.000389125 s, 0.0 kB/s
```

This fails with an "Input/output error" because, by default, the kernel respects memory protection flags for self-writes, but we don't have any access permissions.

**Example 3: With `CONFIG_PROC_MEM_NO_FORCE=y` (`force_override=never`) and yama.ptrace_scope=0**
```
$ ./poc &
[1] 1310
PID: 1310
Stack: 0x7fff4c04c02c
Exec: 0x7fd55e06e000
Text: 0x5565f9ec31c9
Value: 5

# Writing to writable stack memory still works:
$ echo '0x2a000000' | xxd -p -r | dd of=/proc/1310/mem bs=1 seek=$((0x7fff4c04c02c)) count=4 conv=notrunc
4+0 records in
4+0 records out
4 bytes copied, 0.000447966 s, 8.9 kB/s

# Writing to protected (executable) memory now fails:
$ echo '0x2a000000' | xxd -p -r | dd of=/proc/1310/mem bs=1 seek=$((0x5565f9ec31c9)) count=4 conv=notrunc
dd: error writing '/proc/1310/mem': Input/output error
1+0 records in
0+0 records out
0 bytes copied, 0.000521603 s, 0.0 kB/s
```
With `force_override=never`, the kernel now correctly prevents writes to non-writable memory regions (like the text section) **even within the same self process**.

---

#### **The Security Gap and the Necessity of `proc_mem.force_override`**

While `kernel.yama.ptrace_scope` effectively protects *other* processes, it does not prevent a compromised process from modifying its *own* protected memory pages. This creates a security gap, as self-modification can be exploited to trigger race condition vulnerabilities (e.g., [CVE-2022-2590](https://github.com/hyeonjun17/CVE-2022-2590-analysis/tree/main))!

Therefore, for comprehensive protection, you must either:
1.  Set `force_override=ptrace` and completely disable unprivileged ptrace (which is often impractical), or
2.  Set `force_override=never` OR `CONFIG_PROC_MEM_NO_FORCE` to fully disable the `FOLL_FORCE`, ensuring the kernel enforces memory protection flags under all circumstances.

The `proc_mem.force_override` setting provides finer-grained control over userspace memory write permissions.