### PR TITLE
fix(checks.py): handle false negative properly if `ipv6.disable=1`

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -852,6 +852,7 @@ no_kstrtobool_options = [
     'intel_iommu', # see intel_iommu_setup() in drivers/iommu/intel/iommu.c
     'efi', # see efi_parse_options() in drivers/firmware/efi/libstub/efi-stub-helper.c
     'hash_pointers', # see hash_pointers_mode_parse() in lib/vsprintf.c
+    'ipv6.disable', # see the disable_ipv6_mod parameter in net/ipv6/af_inet6.c
     'proc_mem.force_override' # see early_proc_mem_force_override() in fs/proc/base.c
 ]
 


### PR DESCRIPTION
if kernel command line value `ipv6.disable` is set to `1` -- there is no way to write some sysctls:

```console
~> cat /proc/cmdline | grep -o "ipv6..........."
ipv6.disable=1
~> sudo sysctl -w net.ipv6.conf.all.disable_policy=0
sysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_policy: No such file or directory
~ [1]> sudo sysctl -w net.ipv4.conf.all.accept_redirects=0
net.ipv4.conf.all.accept_redirects = 0
~> sudo sysctl -w net.ipv6.conf.all.accept_redirects=0
sysctl: cannot stat /proc/sys/net/ipv6/conf/all/accept_redirects: No such file or directory
~ [1]>
```

let's modify `net.ipv6.*` checks with `OR(...)`

---

i hope you are okay with variable `ipv6_disable` i created. if you are not -- ill fix that :pray: 