### PR TITLE
add apparmor_restrict_unprivileged_unconfined check

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -901,9 +901,10 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
     l += [SysctlCheck('self_protection', 'a13xp0p0v', 'kernel.warn_limit', '100')]
 
     # 'security_policy'
-    l += [SysctlCheck('security_policy', 'ubuntu', 'kernel.apparmor_restrict_unprivileged_unconfined', '1')]
-          # Forbid unprivileged and unconfined processes to change their AppArmor profiles
-          # https://discourse.ubuntu.com/t/understanding-apparmor-user-namespace-restriction/58007
+    l += [OR(SysctlCheck('security_policy', 'ubuntu', 'kernel.apparmor_restrict_unprivileged_unconfined', '1'),
+             SysctlCheck('-', '-', 'kernel.apparmor_restrict_unprivileged_unconfined', 'is not set'))]
+             # Forbid unprivileged and unconfined processes to change their AppArmor profiles
+             # https://discourse.ubuntu.com/t/understanding-apparmor-user-namespace-restriction/58007
 
     # 'cut_attack_surface', 'kspp'
     l += [SysctlCheck('cut_attack_surface', 'kspp', 'kernel.dmesg_restrict', '1')]


### PR DESCRIPTION
Hello @a13xp0p0v! 

I have been studying namespace protection in Ubuntu. It seems to be extremely easy to bypass, since in its basic variation, Apparmor allows you to change the protection profile of your process. This way, you can remove all restrictions, which opens up the system to attack.

For example: https://u1f383.github.io/linux/2025/06/26/the-journey-of-bypassing-ubuntus-unprivileged-namespace-restriction.html

Initially, I thought about such a check:
```
    l += [OR(SysctlCheck('cut_attack_surface', 'a13xp0p0v', 'kernel.apparmor_restrict_unprivileged_unconfined', '1'),
             SysctlCheck('cut_attack_surface', 'kspp', 'user.max_user_namespaces', '0'),
             SysctlCheck('cut_attack_surface', 'debian', 'kernel.unprivileged_userns_clone', '0'),
             AND(KconfigCheck('cut_attack_surface', 'clipos', 'USER_NS', 'is not set'),
                 have_kconfig))]
             # Prevents an attacker from changing own process AppArmor profiles
             # for example, it can be used to bypassing user namespace hardening in ubuntu
             # https://u1f383.github.io/linux/2025/06/26/the-journey-of-bypassing-ubuntus-unprivileged-namespace-restriction.html
```

But I think the problem may actually be much deeper, since Apparmor is used not only to restricts namespaces, but also has many security settings in general. Therefore, the check must be standalone, since the setting allows you to ignore AppArmor security policy, which is a security hole.
