### PR TITLE
Add handling for sysctls without permission

### DIFF
--- a/kernel_hardening_checker/__init__.py
+++ b/kernel_hardening_checker/__init__.py
@@ -93,7 +93,7 @@ def detect_arch_by_kconfig(fname: str) -> tuple[StrOrNone, str]:
 
     with _open(fname) as f:
         for line in f.readlines():
-            if m := re.search("CONFIG_([A-Z0-9_]+)=y$", line):
+            if m := re.match("CONFIG_([A-Z0-9_]+)=y$", line):
                 option = m.group(1)
                 if option not in SUPPORTED_ARCHS:
                     continue
@@ -121,7 +121,7 @@ def detect_arch_by_sysctl(fname: str) -> tuple[StrOrNone, str]:
                 value = line.split('=', 1)[1].strip()
                 for arch, pattern in arch_mapping.items():
                     assert(arch in SUPPORTED_ARCHS), 'invalid arch mapping in sysctl'
-                    if re.search(pattern, value):
+                    if re.match(pattern, value):
                         return arch, value
                 return None, f'{value} is an unsupported arch'
         return None, 'failed to detect architecture in sysctl'


### PR DESCRIPTION
Hello, I used `auto` mode in kernel-hardening-checker, and there is one detail that often confuses me. When we parse sysctl, if we don't have sufficient permissions for a certain line, we only get a small notification at the top of the list:
`[!] WARNING: sysctl options available for root are not found in /tmp/sysctl-jfvhwyc_, try checking the output of "sudo sysctl -a"`

When working with the tool, my focus is mainly on the table itself, and for example, when configuring only sysctl, I may never see this warning at all, or simply miss it. While the option is always shown as "Not found", for example:
```
vm.mmap_rnd_bits                      |sysctl | harden_userspace |a13xp0p0v |     32     | FAIL: is not found
vm.mmap_rnd_compat_bits               |sysctl | harden_userspace |a13xp0p0v |     16     | FAIL: is not found
```

Since this situation is mainly characteristic of sysctl, I suggest adding the permission error processing method. Then, in the output, we will clearly see the sysctl that were not returned due to permission, rather than those that are actually missing:
vm.mmap_rnd_bits                      |sysctl | harden_userspace |a13xp0p0v |     32     | FAIL: "permission denied"
vm.mmap_rnd_compat_bits               |sysctl | harden_userspace |a13xp0p0v |     16     | FAIL: "permission denied"

I am sending the implementation as “prototype” format for now, so that we can decide whether it is worth developing this idea further. If you have any thoughts on how to improve the code, please feel free to share them.