### PR TITLE
Iommu checks

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -130,6 +130,8 @@ def add_kconfig_checks(l: list[ChecklistObjType], arch: str) -> None:
         l += [OR(KconfigCheck('self_protection', 'defconfig', 'MITIGATION_VMSCAPE', 'y'),
                  KconfigCheck('-', '-', 'KVM', 'is not set'))]
     if arch in {'ARM64', 'ARM', 'RISCV'}:
+        l += [KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_DMA_LAZY', 'is not set')]
+              # mutually exclusive with IOMMU_DEFAULT_DMA_STRICT
         l += [KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [KconfigCheck('self_protection', 'defconfig', 'STACKPROTECTOR_PER_TASK', 'y')]
     if arch in {'ARM64', 'ARM'}:
@@ -306,6 +308,8 @@ def add_kconfig_checks(l: list[ChecklistObjType], arch: str) -> None:
                   cfi_clang_is_set,
                   cc_is_clang)]
     if arch in {'X86_64', 'X86_32'}:
+        l += [KconfigCheck('self_protection', 'kspp', 'IOMMU_DEFAULT_DMA_LAZY', 'is not set')]
+              # mutually exclusive with IOMMU_DEFAULT_DMA_STRICT
         l += [KconfigCheck('self_protection', 'kspp', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [AND(KconfigCheck('self_protection', 'kspp', 'INTEL_IOMMU_DEFAULT_ON', 'y'),
                   iommu_support_is_set)]

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -701,6 +701,9 @@ def add_cmdline_checks(l: list[ChecklistObjType], arch: str) -> None:
         l += [OR(CmdlineCheck('self_protection', 'defconfig', 'vmscape', 'is not off'),
                  AND(CmdlineCheck('self_protection', 'kspp', 'mitigations', 'auto,nosmt'),
                      CmdlineCheck('-', '-', 'vmscape', 'is not set')))]
+    if arch == 'X86_64':
+        l += [OR(CmdlineCheck('self_protection', 'defconfig', 'amd_iommu', 'is not off'),
+                 CmdlineCheck('self_protection', 'defconfig', 'amd_iommu', 'is not set'))]
     if arch == 'ARM64':
         l += [OR(CmdlineCheck('self_protection', 'defconfig', 'kpti', 'is not off'),
                  AND(CmdlineCheck('self_protection', 'defconfig', 'mitigations', 'auto'),
@@ -877,6 +880,7 @@ no_kstrtobool_options = [
     'tsx',  # see tsx_init() in arch/x86/kernel/cpu/tsx.c
     'lockdown',  # see lockdown_param() in security/lockdown/lockdown.c
     'intel_iommu',  # see intel_iommu_setup() in drivers/iommu/intel/iommu.c
+    'amd_iommu',  # see parse_amd_iommu_options() in drivers/iommu/amd/init.c
     'efi',  # see efi_parse_options() in drivers/firmware/efi/libstub/efi-stub-helper.c
     'hash_pointers',  # see hash_pointers_mode_parse() in lib/vsprintf.c
     'ipv6.disable',  # see the disable_ipv6_mod parameter in net/ipv6/af_inet6.c

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -130,9 +130,9 @@ def add_kconfig_checks(l: list[ChecklistObjType], arch: str) -> None:
         l += [OR(KconfigCheck('self_protection', 'defconfig', 'MITIGATION_VMSCAPE', 'y'),
                  KconfigCheck('-', '-', 'KVM', 'is not set'))]
     if arch in {'ARM64', 'ARM', 'RISCV'}:
+        l += [KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_DMA_LAZY', 'is not set')]
               # mutually exclusive with IOMMU_DEFAULT_DMA_STRICT
-        l += [KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [KconfigCheck('self_protection', 'defconfig', 'STACKPROTECTOR_PER_TASK', 'y')]
     if arch in {'ARM64', 'ARM'}:
         l += [KconfigCheck('self_protection', 'defconfig', 'HW_RANDOM_TPM', 'y')]
@@ -308,9 +308,9 @@ def add_kconfig_checks(l: list[ChecklistObjType], arch: str) -> None:
                   cfi_clang_is_set,
                   cc_is_clang)]
     if arch in {'X86_64', 'X86_32'}:
+        l += [KconfigCheck('self_protection', 'kspp', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [KconfigCheck('self_protection', 'kspp', 'IOMMU_DEFAULT_DMA_LAZY', 'is not set')]
               # mutually exclusive with IOMMU_DEFAULT_DMA_STRICT
-        l += [KconfigCheck('self_protection', 'kspp', 'IOMMU_DEFAULT_DMA_STRICT', 'y')]
         l += [AND(KconfigCheck('self_protection', 'kspp', 'INTEL_IOMMU_DEFAULT_ON', 'y'),
                   iommu_support_is_set)]
     if arch in {'ARM64', 'RISCV'}:

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -221,10 +221,19 @@ class ComplexOptCheck:
         self.opts = opts
         assert (self.opts), \
                f'empty {self.__class__.__name__} check'
-        assert (len(self.opts) != 1), \
-               f'useless {self.__class__.__name__} check: {opts}'
-        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), \
-               f'invalid {self.__class__.__name__} check: {opts}'
+        assert (len(self.opts) != 1), (
+            f'useless {self.__class__.__name__} check: '
+            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
+        )
+        assert (not isinstance(self.opts[0], tuple)), (
+            f'invalid {self.__class__.__name__} check: '
+            f'extra parentheses near '
+            f'{getattr(self.opts[0][0], "name", self.opts[0][0].__class__.__name__)}'
+        )
+        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), (
+            f'invalid {self.__class__.__name__} check: '
+            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
+        )
         self.result = None  # type: str | None
 
     @property

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -277,6 +277,11 @@ class OR(ComplexOptCheck):
     #     OR(<X_is_hardened>, <old_X_is_hardened>)
     def check(self) -> None:
         for i, opt in enumerate(self.opts):
+            if i != 0:
+                assert not isinstance(opt, OR), (
+                    f'redundant nested OR; flatten into a single OR(...)'
+                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
+                )
             opt.check()
             assert (opt.result), 'unexpected empty result of the OR sub-check'
             if opt.result.startswith('OK'):
@@ -311,6 +316,11 @@ class AND(ComplexOptCheck):
     #     AND(<X_is_disabled>, <old_X_is_disabled>)
     def check(self) -> None:
         for i, opt in reversed(list(enumerate(self.opts))):
+            if i != 0:
+                assert not isinstance(opt, AND), (
+                    f'redundant nested AND; flatten into a single AND(...)'
+                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
+                )
             opt.check()
             assert (opt.result), 'unexpected empty result of the AND sub-check'
             if i == 0:

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -102,12 +102,13 @@ class OptCheck:
 
         # handle the 'is not off' option check
         if self.expected == 'is not off':
-            if self.state == 'off':
-                self.result = 'FAIL: is off'
+            if self.state is None:
+                self.result = 'FAIL: is off, not found'
             elif self.state in {'0', 'is not set'}:
                 self.result = f'FAIL: is off, "{self.state}"'
-            elif self.state is None:
-                self.result = 'FAIL: is off, not found'
+            # split(',') works for both lists and single strings
+            elif 'off' in self.state.strip('"').split(','):
+                self.result = 'FAIL: is off'
             else:
                 self.result = f'OK: is not off, "{self.state}"'
             return

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -278,6 +278,11 @@ class OR(ComplexOptCheck):
     #     OR(<X_is_hardened>, <old_X_is_hardened>)
     def check(self) -> None:
         for i, opt in enumerate(self.opts):
+            if i != 0:
+                assert not isinstance(opt, OR), (
+                    f'redundant nested OR; flatten into a single OR(...)'
+                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
+                )
             opt.check()
             assert (opt.result), 'unexpected empty result of the OR sub-check'
             if opt.result.startswith('OK'):
@@ -312,6 +317,11 @@ class AND(ComplexOptCheck):
     #     AND(<X_is_disabled>, <old_X_is_disabled>)
     def check(self) -> None:
         for i, opt in reversed(list(enumerate(self.opts))):
+            if i != 0:
+                assert not isinstance(opt, AND), (
+                    f'redundant nested AND; flatten into a single AND(...)'
+                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
+                )
             opt.check()
             assert (opt.result), 'unexpected empty result of the AND sub-check'
             if i == 0:

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -107,11 +107,11 @@ class OptCheck:
             elif self.state == 'off':
                 self.result = 'FAIL: is off'
             elif 'off' in self.state.strip('"').split(','):
-                self.result = f'FAIL: is off, "{self.state}"'
+                self.result = f'FAIL: is off ({self.state})'
             elif self.state in {'0', 'is not set'}:
-                self.result = f'FAIL: is off, "{self.state}"'
+                self.result = f'FAIL: is off ({self.state})'
             else:
-                self.result = f'OK: is not off, "{self.state}"'
+                self.result = f'OK: is not off ({self.state})'
             return
 
         # handle the option value check
@@ -331,7 +331,9 @@ class AND(ComplexOptCheck):
                     self.result = f'FAIL: "{opt.expected.strip("*")}" is not in {opt.name}'
                 elif opt.result == 'FAIL: is not present':
                     self.result = f'FAIL: {opt.name} is not present'
-                elif opt.result in {'FAIL: is off', 'FAIL: is off, "0"', 'FAIL: is off, "is not set"'}:
+                elif opt.result == 'FAIL: is off':
+                    self.result = f'FAIL: {opt.name} is off'
+                elif opt.result.startswith('FAIL: is off ('):
                     self.result = f'FAIL: {opt.name} is off'
                 else:
                     assert (opt.result == 'FAIL: is off, not found'), \

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -104,11 +104,12 @@ class OptCheck:
         if self.expected == 'is not off':
             if self.state is None:
                 self.result = 'FAIL: is off, not found'
+            elif self.state == 'off':
+                self.result = 'FAIL: is off'
+            elif 'off' in self.state.strip('"').split(','):
+                self.result = f'FAIL: is off, "{self.state}"'
             elif self.state in {'0', 'is not set'}:
                 self.result = f'FAIL: is off, "{self.state}"'
-            # split(',') works for both lists and single strings
-            elif 'off' in self.state.strip('"').split(','):
-                self.result = 'FAIL: is off'
             else:
                 self.result = f'OK: is not off, "{self.state}"'
             return

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -106,7 +106,7 @@ class OptCheck:
                 self.result = 'FAIL: is off, not found'
             elif self.state == 'off':
                 self.result = 'FAIL: is off'
-            elif 'off' in self.state.strip('"').split(','):
+            elif 'off' in self.state.strip('"').split(','):  # noqa: SIM114
                 self.result = f'FAIL: is off ({self.state})'
             elif self.state in {'0', 'is not set'}:
                 self.result = f'FAIL: is off ({self.state})'
@@ -335,7 +335,7 @@ class AND(ComplexOptCheck):
                     self.result = f'FAIL: "{opt.expected.strip("*")}" is not in {opt.name}'
                 elif opt.result == 'FAIL: is not present':
                     self.result = f'FAIL: {opt.name} is not present'
-                elif opt.result == 'FAIL: is off':
+                elif opt.result == 'FAIL: is off':  # noqa: SIM114
                     self.result = f'FAIL: {opt.name} is off'
                 elif opt.result.startswith('FAIL: is off ('):
                     self.result = f'FAIL: {opt.name} is off'

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -222,10 +222,19 @@ class ComplexOptCheck:
         self.opts = opts
         assert (self.opts), \
                f'empty {self.__class__.__name__} check'
-        assert (len(self.opts) != 1), \
-               f'useless {self.__class__.__name__} check: {opts}'
-        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), \
-               f'invalid {self.__class__.__name__} check: {opts}'
+        assert (len(self.opts) != 1), (
+            f'useless {self.__class__.__name__} check: '
+            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
+        )
+        assert (not isinstance(self.opts[0], tuple)), (
+            f'invalid {self.__class__.__name__} check: '
+            f'extra parentheses near '
+            f'{getattr(self.opts[0][0], "name", self.opts[0][0].__class__.__name__)}'
+        )
+        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), (
+            f'invalid {self.__class__.__name__} check: '
+            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
+        )
         self.result = None  # type: str | None
 
     @property

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -222,19 +222,10 @@ class ComplexOptCheck:
         self.opts = opts
         assert (self.opts), \
                f'empty {self.__class__.__name__} check'
-        assert (len(self.opts) != 1), (
-            f'useless {self.__class__.__name__} check: '
-            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
-        )
-        assert (not isinstance(self.opts[0], tuple)), (
-            f'invalid {self.__class__.__name__} check: '
-            f'extra parentheses near '
-            f'{getattr(self.opts[0][0], "name", self.opts[0][0].__class__.__name__)}'
-        )
-        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), (
-            f'invalid {self.__class__.__name__} check: '
-            f'{getattr(self.opts[0], "name", self.opts[0].__class__.__name__)}'
-        )
+        assert (isinstance(self.opts[0], SimpleNamedOptCheckTypes)), \
+               f'invalid {self.__class__.__name__} check starting from {self.opts[0].__class__.__name__}'
+        assert (len(self.opts) != 1), \
+               f'useless {self.__class__.__name__} in the "{self.name}" check'
         self.result = None  # type: str | None
 
     @property

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -279,10 +279,7 @@ class OR(ComplexOptCheck):
     def check(self) -> None:
         for i, opt in enumerate(self.opts):
             if i != 0:
-                assert not isinstance(opt, OR), (
-                    f'redundant nested OR; flatten into a single OR(...)'
-                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
-                )
+                assert (not isinstance(opt, OR)), f'redundant nested OR in the "{self.name}" check'
             opt.check()
             assert (opt.result), 'unexpected empty result of the OR sub-check'
             if opt.result.startswith('OK'):
@@ -318,10 +315,7 @@ class AND(ComplexOptCheck):
     def check(self) -> None:
         for i, opt in reversed(list(enumerate(self.opts))):
             if i != 0:
-                assert not isinstance(opt, AND), (
-                    f'redundant nested AND; flatten into a single AND(...)'
-                    f'\nopts: {", ".join("VersionCheck" if isinstance(o, VersionCheck) else o.name for o in self.opts)}'
-                )
+                assert (not isinstance(opt, AND)), f'redundant nested AND in the "{self.name}" check'
             opt.check()
             assert (opt.result), 'unexpected empty result of the AND sub-check'
             if i == 0:

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -143,9 +143,11 @@ class TestEngine(unittest.TestCase):
         config_checklist += [KconfigCheck('reason_8', 'decision_8', 'NAME_8', 'is not off')]
         config_checklist += [KconfigCheck('reason_9', 'decision_9', 'NAME_9', 'is not off')]
         config_checklist += [KconfigCheck('reason_10', 'decision_10', 'NAME_10', 'is not off')]
-        config_checklist += [KconfigCheck('reason_11', 'decision_11', 'NAME_11', '*expected_11*')]
-        config_checklist += [KconfigCheck('reason_12', 'decision_12', 'NAME_12', '*expected_12*')]
+        config_checklist += [KconfigCheck('reason_11', 'decision_11', 'NAME_11', 'is not off')]
+        config_checklist += [KconfigCheck('reason_12', 'decision_12', 'NAME_12', 'is not off')]
         config_checklist += [KconfigCheck('reason_13', 'decision_13', 'NAME_13', '*expected_13*')]
+        config_checklist += [KconfigCheck('reason_14', 'decision_14', 'NAME_14', '*expected_14*')]
+        config_checklist += [KconfigCheck('reason_15', 'decision_15', 'NAME_15', '*expected_15*')]
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -155,8 +157,10 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_7'] = 'really_not_off'
         parsed_kconfig_options['CONFIG_NAME_8'] = 'off'
         parsed_kconfig_options['CONFIG_NAME_9'] = '0'
-        parsed_kconfig_options['CONFIG_NAME_11'] = '"expected_11,something,UNexpected2"'
-        parsed_kconfig_options['CONFIG_NAME_12'] = 'UNexpected_12,something'
+        parsed_kconfig_options['CONFIG_NAME_11'] = '"something,off"'
+        parsed_kconfig_options['CONFIG_NAME_12'] = '"really_not_off,something"'
+        parsed_kconfig_options['CONFIG_NAME_13'] = '"expected_13,something,UNexpected2"'
+        parsed_kconfig_options['CONFIG_NAME_14'] = 'UNexpected_14,something'
 
         # 3. run the engine
         self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
@@ -176,9 +180,11 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_8', 'type': 'kconfig', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': '*expected_11*', 'check_result': 'OK: in "expected_11,something,UNexpected2"', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': '*expected_12*', 'check_result': 'FAIL: not in UNexpected_12,something', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""really_not_off,something""', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_14', 'type': 'kconfig', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
         )
 
     def test_simple_cmdline(self) -> None:
@@ -194,6 +200,10 @@ class TestEngine(unittest.TestCase):
         config_checklist += [CmdlineCheck('reason_8', 'decision_8', 'name_8', 'is not off')]
         config_checklist += [CmdlineCheck('reason_9', 'decision_9', 'name_9', 'is not off')]
         config_checklist += [CmdlineCheck('reason_10', 'decision_10', 'name_10', 'is not off')]
+        config_checklist += [CmdlineCheck('reason_11', 'decision_11', 'name_11', 'is not off')]
+        config_checklist += [CmdlineCheck('reason_12', 'decision_12', 'name_12', 'is not off')]
+        config_checklist += [CmdlineCheck('reason_13', 'decision_13', 'name_13', '*expected_13*')]
+        config_checklist += [CmdlineCheck('reason_14', 'decision_14', 'name_14', '*expected_14*')]
 
         # 2. prepare the parsed cmdline options
         parsed_cmdline_options = {}
@@ -203,6 +213,10 @@ class TestEngine(unittest.TestCase):
         parsed_cmdline_options['name_7'] = ''
         parsed_cmdline_options['name_8'] = 'off'
         parsed_cmdline_options['name_9'] = '0'
+        parsed_cmdline_options['name_11'] = 'something,off'
+        parsed_cmdline_options['name_12'] = 'really_not_off,something'
+        parsed_cmdline_options['name_13'] = 'expected_13,something'
+        parsed_cmdline_options['name_14'] = 'UNexpected_14,something'
 
         # 3. run the engine
         self.run_engine(config_checklist, None, parsed_cmdline_options, None, None)
@@ -221,7 +235,11 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_7', 'type': 'cmdline', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
                  {'option_name': 'name_8', 'type': 'cmdline', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
                  {'option_name': 'name_9', 'type': 'cmdline', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
-                 {'option_name': 'name_10', 'type': 'cmdline', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}],
+                 {'option_name': 'name_10', 'type': 'cmdline', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
+                 {'option_name': 'name_11', 'type': 'cmdline', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
+                 {'option_name': 'name_12', 'type': 'cmdline', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off, "really_not_off,something"', 'check_result_bool': True},
+                 {'option_name': 'name_13', 'type': 'cmdline', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in expected_13,something', 'check_result_bool': True},
+                 {'option_name': 'name_14', 'type': 'cmdline', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False}],
         )
 
     def test_simple_sysctl(self) -> None:
@@ -296,7 +314,7 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_5'] = 'UNexpected_5'
         parsed_kconfig_options['CONFIG_NAME_6'] = 'UNexpected_6'
         parsed_kconfig_options['CONFIG_NAME_10'] = 'UNexpected_10'
-        parsed_kconfig_options['CONFIG_NAME_12'] = 'really_not_off'
+        parsed_kconfig_options['CONFIG_NAME_12'] = '"really_not_off,something"'
         parsed_kconfig_options['CONFIG_NAME_13'] = 'UNexpected_13'
         parsed_kconfig_options['CONFIG_NAME_14'] = '"UNexpected_14,something,expected_14"'
         parsed_kconfig_options['CONFIG_NAME_15'] = 'UNexpected_15'
@@ -336,9 +354,11 @@ class TestEngine(unittest.TestCase):
         config_checklist += [AND(KconfigCheck('reason_11', 'decision_11', 'NAME_11', 'expected_11'),
                                  KconfigCheck('reason_12', 'decision_12', 'NAME_12', 'is not off'))]
         config_checklist += [AND(KconfigCheck('reason_13', 'decision_13', 'NAME_13', 'expected_13'),
-                                 KconfigCheck('reason_14', 'decision_14', 'NAME_14', '*expected_14*'))]
+                                 KconfigCheck('reason_14', 'decision_14', 'NAME_14', 'is not off'))]
         config_checklist += [AND(KconfigCheck('reason_15', 'decision_15', 'NAME_15', 'expected_15'),
                                  KconfigCheck('reason_16', 'decision_16', 'NAME_16', '*expected_16*'))]
+        config_checklist += [AND(KconfigCheck('reason_17', 'decision_17', 'NAME_17', 'expected_17'),
+                                 KconfigCheck('reason_18', 'decision_18', 'NAME_18', '*expected_18*'))]
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -353,9 +373,11 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_10'] = '0'
         parsed_kconfig_options['CONFIG_NAME_11'] = 'expected_11'
         parsed_kconfig_options['CONFIG_NAME_13'] = 'expected_13'
-        parsed_kconfig_options['CONFIG_NAME_14'] = '"UNexpected_14,something"'
+        parsed_kconfig_options['CONFIG_NAME_14'] = '"something,off"'
         parsed_kconfig_options['CONFIG_NAME_15'] = 'expected_15'
         parsed_kconfig_options['CONFIG_NAME_16'] = 'UNexpected_16,something'
+        parsed_kconfig_options['CONFIG_NAME_17'] = 'expected_17'
+        parsed_kconfig_options['CONFIG_NAME_18'] = 'UNexpected_18,something'
 
         # 3. run the engine
         self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
@@ -371,8 +393,9 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'FAIL: CONFIG_NAME_8 is not present', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'FAIL: CONFIG_NAME_10 is off', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'FAIL: CONFIG_NAME_12 is off, not found', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'FAIL: "expected_14" is not in CONFIG_NAME_14', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'FAIL: "expected_16" is not in CONFIG_NAME_16', 'check_result_bool': False}],
+                 {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'FAIL: CONFIG_NAME_14 is off', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'FAIL: "expected_16" is not in CONFIG_NAME_16', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'FAIL: "expected_18" is not in CONFIG_NAME_18', 'check_result_bool': False}],
         )
 
     def test_complex_nested(self) -> None:

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -204,6 +204,7 @@ class TestEngine(unittest.TestCase):
         config_checklist += [CmdlineCheck('reason_12', 'decision_12', 'name_12', 'is not off')]
         config_checklist += [CmdlineCheck('reason_13', 'decision_13', 'name_13', '*expected_13*')]
         config_checklist += [CmdlineCheck('reason_14', 'decision_14', 'name_14', '*expected_14*')]
+        config_checklist += [CmdlineCheck('reason_15', 'decision_15', 'name_15', '*expected_15*')]
 
         # 2. prepare the parsed cmdline options
         parsed_cmdline_options = {}
@@ -239,7 +240,8 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_11', 'type': 'cmdline', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off ("something,off")', 'check_result_bool': False},
                  {'option_name': 'name_12', 'type': 'cmdline', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
                  {'option_name': 'name_13', 'type': 'cmdline', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
-                 {'option_name': 'name_14', 'type': 'cmdline', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False}],
+                 {'option_name': 'name_14', 'type': 'cmdline', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
+                 {'option_name': 'name_15', 'type': 'cmdline', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
         )
 
     def test_simple_sysctl(self) -> None:
@@ -255,6 +257,11 @@ class TestEngine(unittest.TestCase):
         config_checklist += [SysctlCheck('reason_8', 'decision_8', 'name_8', 'is not off')]
         config_checklist += [SysctlCheck('reason_9', 'decision_9', 'name_9', 'is not off')]
         config_checklist += [SysctlCheck('reason_10', 'decision_10', 'name_10', 'is not off')]
+        config_checklist += [SysctlCheck('reason_11', 'decision_11', 'name_11', 'is not off')]
+        config_checklist += [SysctlCheck('reason_12', 'decision_12', 'name_12', 'is not off')]
+        config_checklist += [SysctlCheck('reason_13', 'decision_13', 'name_13', '*expected_13*')]
+        config_checklist += [SysctlCheck('reason_14', 'decision_14', 'name_14', '*expected_14*')]
+        config_checklist += [SysctlCheck('reason_15', 'decision_15', 'name_15', '*expected_15*')]
 
         # 2. prepare the parsed sysctl options
         parsed_sysctl_options = {}
@@ -264,6 +271,10 @@ class TestEngine(unittest.TestCase):
         parsed_sysctl_options['name_7'] = ''
         parsed_sysctl_options['name_8'] = 'off'
         parsed_sysctl_options['name_9'] = '0'
+        parsed_sysctl_options['name_11'] = '"something,off"'
+        parsed_sysctl_options['name_12'] = 'really_not_off,something'
+        parsed_sysctl_options['name_13'] = '"expected_13,something,UNexpected2"'
+        parsed_sysctl_options['name_14'] = 'UNexpected_14,something'
 
         # 3. run the engine
         self.run_engine(config_checklist, None, None, parsed_sysctl_options, None)
@@ -282,7 +293,12 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_7', 'type': 'sysctl', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off ()', 'check_result_bool': True},
                  {'option_name': 'name_8', 'type': 'sysctl', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
                  {'option_name': 'name_9', 'type': 'sysctl', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off (0)', 'check_result_bool': False},
-                 {'option_name': 'name_10', 'type': 'sysctl', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}],
+                 {'option_name': 'name_10', 'type': 'sysctl', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
+                 {'option_name': 'name_11', 'type': 'sysctl', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off ("something,off")', 'check_result_bool': False},
+                 {'option_name': 'name_12', 'type': 'sysctl', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
+                 {'option_name': 'name_13', 'type': 'sysctl', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
+                 {'option_name': 'name_14', 'type': 'sysctl', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
+                 {'option_name': 'name_15', 'type': 'sysctl', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
         )
 
     def test_complex_or(self) -> None:
@@ -314,7 +330,7 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_5'] = 'UNexpected_5'
         parsed_kconfig_options['CONFIG_NAME_6'] = 'UNexpected_6'
         parsed_kconfig_options['CONFIG_NAME_10'] = 'UNexpected_10'
-        parsed_kconfig_options['CONFIG_NAME_12'] = '"really_not_off,something"'
+        parsed_kconfig_options['CONFIG_NAME_12'] = 'really_not_off'
         parsed_kconfig_options['CONFIG_NAME_13'] = 'UNexpected_13'
         parsed_kconfig_options['CONFIG_NAME_14'] = '"UNexpected_14,something,expected_14"'
         parsed_kconfig_options['CONFIG_NAME_15'] = 'UNexpected_15'
@@ -356,9 +372,11 @@ class TestEngine(unittest.TestCase):
         config_checklist += [AND(KconfigCheck('reason_13', 'decision_13', 'NAME_13', 'expected_13'),
                                  KconfigCheck('reason_14', 'decision_14', 'NAME_14', 'is not off'))]
         config_checklist += [AND(KconfigCheck('reason_15', 'decision_15', 'NAME_15', 'expected_15'),
-                                 KconfigCheck('reason_16', 'decision_16', 'NAME_16', '*expected_16*'))]
+                                 KconfigCheck('reason_16', 'decision_16', 'NAME_16', 'is not off'))]
         config_checklist += [AND(KconfigCheck('reason_17', 'decision_17', 'NAME_17', 'expected_17'),
                                  KconfigCheck('reason_18', 'decision_18', 'NAME_18', '*expected_18*'))]
+        config_checklist += [AND(KconfigCheck('reason_19', 'decision_19', 'NAME_19', 'expected_19'),
+                                 KconfigCheck('reason_20', 'decision_20', 'NAME_20', '*expected_20*'))]
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -370,14 +388,16 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_6'] = 'expected_6'
         parsed_kconfig_options['CONFIG_NAME_7'] = 'expected_7'
         parsed_kconfig_options['CONFIG_NAME_9'] = 'expected_9'
-        parsed_kconfig_options['CONFIG_NAME_10'] = '0'
         parsed_kconfig_options['CONFIG_NAME_11'] = 'expected_11'
+        parsed_kconfig_options['CONFIG_NAME_12'] = 'off'
         parsed_kconfig_options['CONFIG_NAME_13'] = 'expected_13'
         parsed_kconfig_options['CONFIG_NAME_14'] = '"something,off"'
-        parsed_kconfig_options['CONFIG_NAME_15'] = 'expected_15'
-        parsed_kconfig_options['CONFIG_NAME_16'] = 'UNexpected_16,something'
-        parsed_kconfig_options['CONFIG_NAME_17'] = 'expected_17'
-        parsed_kconfig_options['CONFIG_NAME_18'] = 'UNexpected_18,something'
+        parsed_kconfig_options['CONFIG_NAME_15'] = 'expected_13'
+        parsed_kconfig_options['CONFIG_NAME_16'] = '0'
+        parsed_kconfig_options['CONFIG_NAME_17'] = 'expected_13'
+        parsed_kconfig_options['CONFIG_NAME_18'] = '"UNexpected_14,something"'
+        parsed_kconfig_options['CONFIG_NAME_19'] = 'expected_15'
+        parsed_kconfig_options['CONFIG_NAME_20'] = 'UNexpected_16,something'
 
         # 3. run the engine
         self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
@@ -391,11 +411,12 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_3', 'type': 'kconfig', 'reason': 'reason_3', 'decision': 'decision_3', 'desired_val': 'expected_3', 'check_result': 'FAIL: CONFIG_NAME_4 is not "expected_4"', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'expected_5', 'check_result': 'FAIL: "UNexpected_5"', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'expected_7', 'check_result': 'FAIL: CONFIG_NAME_8 is not present', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'FAIL: CONFIG_NAME_10 is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'FAIL: CONFIG_NAME_12 is off, not found', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'FAIL: CONFIG_NAME_10 is off, not found', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'FAIL: CONFIG_NAME_12 is off', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'FAIL: CONFIG_NAME_14 is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'FAIL: "expected_16" is not in CONFIG_NAME_16', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'FAIL: "expected_18" is not in CONFIG_NAME_18', 'check_result_bool': False}],
+                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'FAIL: CONFIG_NAME_16 is off', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'FAIL: "expected_18" is not in CONFIG_NAME_18', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_19', 'type': 'kconfig', 'reason': 'reason_19', 'decision': 'decision_19', 'desired_val': 'expected_19', 'check_result': 'FAIL: "expected_20" is not in CONFIG_NAME_20', 'check_result_bool': False}],
         )
 
     def test_complex_nested(self) -> None:

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -158,7 +158,7 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_8'] = 'off'
         parsed_kconfig_options['CONFIG_NAME_9'] = '0'
         parsed_kconfig_options['CONFIG_NAME_11'] = '"something,off"'
-        parsed_kconfig_options['CONFIG_NAME_12'] = '"really_not_off,something"'
+        parsed_kconfig_options['CONFIG_NAME_12'] = 'really_not_off,something'
         parsed_kconfig_options['CONFIG_NAME_13'] = '"expected_13,something,UNexpected2"'
         parsed_kconfig_options['CONFIG_NAME_14'] = 'UNexpected_14,something'
 
@@ -176,12 +176,12 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_4', 'type': 'kconfig', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_5', 'type': 'kconfig', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_6', 'type': 'kconfig', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, "really_not_off"', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_7', 'type': 'kconfig', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off)', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_8', 'type': 'kconfig', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off (0)', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_10', 'type': 'kconfig', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""really_not_off,something""', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off ("something,off")', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_12', 'type': 'kconfig', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_14', 'type': 'kconfig', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
@@ -213,9 +213,9 @@ class TestEngine(unittest.TestCase):
         parsed_cmdline_options['name_7'] = ''
         parsed_cmdline_options['name_8'] = 'off'
         parsed_cmdline_options['name_9'] = '0'
-        parsed_cmdline_options['name_11'] = 'something,off'
+        parsed_cmdline_options['name_11'] = '"something,off"'
         parsed_cmdline_options['name_12'] = 'really_not_off,something'
-        parsed_cmdline_options['name_13'] = 'expected_13,something'
+        parsed_cmdline_options['name_13'] = '"expected_13,something,UNexpected2"'
         parsed_cmdline_options['name_14'] = 'UNexpected_14,something'
 
         # 3. run the engine
@@ -232,13 +232,13 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_4', 'type': 'cmdline', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
                  {'option_name': 'name_5', 'type': 'cmdline', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
                  {'option_name': 'name_6', 'type': 'cmdline', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'name_7', 'type': 'cmdline', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
+                 {'option_name': 'name_7', 'type': 'cmdline', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off ()', 'check_result_bool': True},
                  {'option_name': 'name_8', 'type': 'cmdline', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'name_9', 'type': 'cmdline', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'name_9', 'type': 'cmdline', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off (0)', 'check_result_bool': False},
                  {'option_name': 'name_10', 'type': 'cmdline', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False},
-                 {'option_name': 'name_11', 'type': 'cmdline', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'name_12', 'type': 'cmdline', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off, "really_not_off,something"', 'check_result_bool': True},
-                 {'option_name': 'name_13', 'type': 'cmdline', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in expected_13,something', 'check_result_bool': True},
+                 {'option_name': 'name_11', 'type': 'cmdline', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'is not off', 'check_result': 'FAIL: is off ("something,off")', 'check_result_bool': False},
+                 {'option_name': 'name_12', 'type': 'cmdline', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
+                 {'option_name': 'name_13', 'type': 'cmdline', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
                  {'option_name': 'name_14', 'type': 'cmdline', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False}],
         )
 
@@ -279,9 +279,9 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_4', 'type': 'sysctl', 'reason': 'reason_4', 'decision': 'decision_4', 'desired_val': 'is not set', 'check_result': 'OK: is not found', 'check_result_bool': True},
                  {'option_name': 'name_5', 'type': 'sysctl', 'reason': 'reason_5', 'decision': 'decision_5', 'desired_val': 'is present', 'check_result': 'OK: is present', 'check_result_bool': True},
                  {'option_name': 'name_6', 'type': 'sysctl', 'reason': 'reason_6', 'decision': 'decision_6', 'desired_val': 'is present', 'check_result': 'FAIL: is not present', 'check_result_bool': False},
-                 {'option_name': 'name_7', 'type': 'sysctl', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off, ""', 'check_result_bool': True},
+                 {'option_name': 'name_7', 'type': 'sysctl', 'reason': 'reason_7', 'decision': 'decision_7', 'desired_val': 'is not off', 'check_result': 'OK: is not off ()', 'check_result_bool': True},
                  {'option_name': 'name_8', 'type': 'sysctl', 'reason': 'reason_8', 'decision': 'decision_8', 'desired_val': 'is not off', 'check_result': 'FAIL: is off', 'check_result_bool': False},
-                 {'option_name': 'name_9', 'type': 'sysctl', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, "0"', 'check_result_bool': False},
+                 {'option_name': 'name_9', 'type': 'sysctl', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'is not off', 'check_result': 'FAIL: is off (0)', 'check_result_bool': False},
                  {'option_name': 'name_10', 'type': 'sysctl', 'reason': 'reason_10', 'decision': 'decision_10', 'desired_val': 'is not off', 'check_result': 'FAIL: is off, not found', 'check_result_bool': False}],
         )
 


### PR DESCRIPTION
Hello @a13xp0p0v , I've brought one new check and a small update to the engine with a huge story for #182 

Let's go through everything step by step:

`CONFIG_IOMMU_DEFAULT_DMA_LAZY` is part of the IOMMU default-domain Kconfig choice and explicitly trades isolation for performance.

Upstream Kconfig describes it as:

- lazy / batched TLB invalidation
- equivalent to `iommu.passthrough=0 iommu.strict=0`

See:
- Kconfig: https://github.com/torvalds/linux/blob/master/drivers/iommu/Kconfig

So, since it also mutually exclusive with IOMMU_DEFAULT_DMA_STRICT we recommend it as 'is not set' option

As for `amd_iommu=force_isolation`, it should NOT be added!

First, I considered something like
```
    # 'self_protection', 'a13xp0p0v'
    if arch in {'X86_64', 'X86_32'}:
        l += [AND(CmdlineCheck('self_protection', 'a13xp0p0v', 'amd_iommu', '*force_isolation*'),
                  CmdlineCheck('self_protection', 'defconfig', 'amd_iommu', 'is not off'),
                  KconfigCheck('self_protection', 'defconfig', 'IOMMU_DEFAULT_PASSTHROUGH', 'is not set'),
                  CmdlineCheck('-', '-', 'iommu.passthrough', 'is not set'))]
              # will be almost useless if any iommu passthrough present, including iommu=pt

	...
	'amd_iommu'  # see parse_amd_iommu_options() in drivers/iommu/amd/init.c
	...
```

But while preparing this change, I investigated how `amd_iommu=force_isolation` is really affecting AMD, here are some findings against  it:

### 1) It can be destroyed by another cmdline

The kernel parameter documentation describes `amd_iommu=force_isolation` as forcing device isolation, but also explicitly states that it does not override `iommu=pt`:

- kernel params: https://docs.kernel.org/admin-guide/kernel-parameters.html

That already makes it less clean since we don't have check `iommu is not pt`)

### 2) There are some evidence of problems with that check

https://github.com/linux-surface/linux-surface/discussions/480

I've found open discussions where people experience crashes with amd_iommu=force_isolation, which seems common for many distributions and surroundings. 

### 3) Looks like it  is considered as debug option rather that useful one

In code comments, it is described as a debug option:

```
/*
 * By default we use passthrough mode for IOMMUv2 capable device.
 * But if amd_iommu=force_isolation is set (e.g. to debug DMA to
 * invalid address), we ignore the capability for the device so
 * it'll be forced to go into translation mode.
 */
```

Src: https://elixir.bootlin.com/linux/v7.0/source/drivers/iommu/amd/iommu.c#L722

### 4) I've performed validation on real hardware

I did not stop at reading. I validated behavior on a real AMD system and compared multiple boot profiles.

### Test system

- kernel: `6.17.10+kali-amd64`
- tested device: `0000:16:00.0` (AMD integrated GPU)
- PCI ID: `Advanced Micro Devices, Inc. [AMD/ATI] Raphael [1002:164e]`
- group mapping validated via:
  - `/proc/cmdline`
  - `journalctl -k -b | grep -Ei 'AMD-Vi|IOMMU|IVRS|DMAR'`
  - `/sys/kernel/iommu_groups/*/type`
  - `lspci -nn -s 16:00.0`
  - `readlink -f /sys/bus/pci/devices/0000:16:00.0/iommu_group`

For the meaning of `/sys/kernel/iommu_groups/<grp_id>/type`, see the ABI documentation:
- https://docs.kernel.org/admin-guide/abi-testing.html#abi-sys-kernel-iommu-groups-grp-id-type

### Workloads

I used two graphics workloads instead of relying on logs alone:

- `glmark2`: https://github.com/glmark2/glmark2
- `MotionMark`: https://browserbench.org/MotionMark/

I also manually plugged the monitor both into the discrete GPU (HDMI on the RTX 3070) and integrated one and observed runtime behavior with:
- `nvidia-smi`
- `radeontop`

##### Baseline boot

- `/sys/kernel/iommu_groups/25/type` = `identity`
- `glmark2` score = `4750`
- `MotionMark` score = `644.31`
- no visible artifacts
- no display degradation

Interpretation:
the tested integrated graphics device was effectively outside DMA protection for that group and works fine

##### `amd_iommu=force_isolation`

Observed:

- `/sys/kernel/iommu_groups/25/type` changed from `identity` to `DMA-FQ`
- `glmark2` score = `5023` (surprisingly a bit higher)
- `MotionMark` caused progressive display corruption after a few minutes
- the display became effectively unusable over like 10 minutes

Interpretation:
the parameter did change the default domain type in the expected hardening direction, but introduced a full graphics instability on this hardware. After a while It was simply unable to use monitor at all.

##### `amd_iommu=force_isolation iommu.strict=1`

Observed:

- `/sys/kernel/iommu_groups/25/type` changed to `DMA`
- the same progressive display degradation remained
- under load, the system started reporting repeated `amdgpu` failures such as:
  - `Illegal register access in command stream`
  - `ring gfx_0.0.0 timeout`
  - GPU reset / recovery messages

Interpretation:
strict invalidation changed `DMA-FQ` to `DMA`, same runtime instability. Also, I've got even some crash logs from GPU itself:
```
[  318.830521] [drm:gfx_v10_0_priv_reg_irq [amdgpu]] *ERROR* Illegal register access in command stream
[  318.830694] amdgpu 0000:16:00.0: amdgpu: Dumping IP State
[  318.831683] amdgpu 0000:16:00.0: amdgpu: Dumping IP State Completed
[  318.831725] amdgpu 0000:16:00.0: amdgpu: [drm] AMDGPU device coredump file has been created
[  318.831726] amdgpu 0000:16:00.0: amdgpu: [drm] Check your /sys/class/drm/card0/device/devcoredump/data
[  318.831728] amdgpu 0000:16:00.0: amdgpu: ring gfx_0.0.0 timeout, signaled seq=2476367, emitted seq=2476369
[  318.831730] amdgpu 0000:16:00.0: amdgpu:  Process Xorg pid 2746 thread Xorg:cs0 pid 2750
[  318.831732] amdgpu 0000:16:00.0: amdgpu: Starting gfx_0.0.0 ring reset
[  318.972455] amdgpu 0000:16:00.0: amdgpu: Ring gfx_0.0.0 reset failed
```

#####  `iommu.strict=1` without `amd_iommu=force_isolation`

Observed:

- translated groups switched from `DMA-FQ` to `DMA`
- The AMD GPU group still remained `identity`

Interpretation:
`iommu.strict=1` improves invalidation behavior for already-translated groups, but it does not by itself pull an identity-mapped device into translation mode. No problems for this time, since AMD GPU is simply untouched, but it is not a full DMA hardening.

I also verified that:

```
amd_iommu=force_isolation,off
```

Effectively disables AMD IOMMU initialization. However, we cannot simply add a check to ensure that it is not turned off, since this would require defining the parameter itself, and no default value has been specified for it -- only a potentially dangerous configuration options. So for now, I think it is better to simply not to touch it at all.

### Engine modifications

First of all, While I was working on the check itself, I added a `is not off` check for the lists, so, now something like:
`option=on,off` will fail as it should

https://github.com/a13xp0p0v/kernel-hardening-checker/commit/599a7e6cd8a37ef688cc864251489ae9e758fed1

And also added some new tests:
https://github.com/a13xp0p0v/kernel-hardening-checker/commit/818930b5bed9b29e6072a68ee93a3e2dac6a5968

I also noticed that malformed `AND()/OR()` checks produced poor assertion messages, so, I've decided to enrich the logs.

First of all, I've fixed situation with nested checks like `OR(...OR(...))` and `AND(...AND(...))`:

Now we have correct error message instead of some hidden 'invalid value':
```
AssertionError: redundant nested AND; flatten into a single AND(...)
opts: amd_iommu, amd_iommu, CONFIG_IOMMU_DEFAULT_PASSTHROUGH
```

Made it with adding new assertion in OR and AND checks:
https://github.com/a13xp0p0v/kernel-hardening-checker/commit/2ad4d1896271b151ecf5c4dab3ba2dc2d89b0247

For some invalid checks like:
```
    l += [AND(CmdlineCheck('test', 'test', 'test', 'test'))]

    l += [AND((KconfigCheck('test1', 'test1', 'test1', 'test1'),
               CmdlineCheck('test', 'test', 'test', 'test'))]

    l += [AND(AND(KconfigCheck('test2', 'test2', 'test2', 'test2'),
                  CmdlineCheck('test', 'test', 'test', 'test')),
                  KconfigCheck('test', 'test', 'test', 'test'))]
```

Like with an extra parenthesis, two consecutive AND operators, or an AND operator with a single argument. We had an assertion log, but it wasn't at all clear what was wrong, since all we had are some internal tuple addresses:
```
AssertionError: useless AND check: (<kernel_hardening_checker.engine.AND object at 0x...>,)
AssertionError: invalid AND check: ((<kernel_hardening_checker.engine.KconfigCheck object at 0x...>, <kernel_hardening_checker.engine.CmdlineCheck object at 0x...>), ...)
```

That was hard to read and did not clearly show what was wrong. I changed the assertion messages to report the actual malformed check in a simpler way. Now the same failures look like this:
```text
AssertionError: useless AND check: test
AssertionError: invalid AND check: extra parentheses near CONFIG_test1
AssertionError: invalid AND check: CONFIG_test2
```
This does not change behavior. But I think it makes malformed composite checks easier to notice and fix.

I've made it with gerattr: https://github.com/a13xp0p0v/kernel-hardening-checker/commit/25767a40d7cd3f479262061997cb9503cc8349eb

So it works like “show the name, and if there isn’t one, at least the class name, so we don’t print something strange”