### PR TITLE
Fix a faulty permission check on sysctl

### DIFF
--- a/kernel_hardening_checker/cli.py
+++ b/kernel_hardening_checker/cli.py
@@ -290,16 +290,17 @@ def parse_sysctl_file(mode: StrOrNone, parsed_options: dict[str, str], fname: st
             sys.exit(f'[-] ERROR: empty sysctl file "{fname}"')
 
         sysctl_pattern = re.compile(r'[a-zA-Z0-9/*._-]+ ?=.*$')
-        sysctl_eperm_pattern = re.compile(r"sysctl: permission denied on key '([a-zA-Z0-9/*._-]+)'")
+        sysctl_eperm_pattern = re.compile(r"^[a-z0-9.]+: permission denied on key '([a-zA-Z0-9/*._-]+)'")
         for l in f.readlines():
             line = l.strip()
             if not line or line.startswith('#'):
                 continue
             if line.startswith('sysctl: '):
                 # this line came from stderr
-                if m := sysctl_eperm_pattern.match(line):
-                    option = m.group(1)
-                    parsed_options[option] = 'permission denied'
+                continue
+            if m := sysctl_eperm_pattern.match(line):
+                option = m.group(1)
+                parsed_options[option] = 'permission denied'
                 continue
             if not sysctl_pattern.match(line):
                 sys.exit(f'[-] ERROR: unexpected line in sysctl file: "{line}"')


### PR DESCRIPTION
Before:

```console
$ ./bin/kernel-hardening-checker -a
[+] Going to autodetect and check the security hardening options of the running kernel
[+] Detected version of the running kernel: (6, 19, 13)
[+] Detected kconfig file of the running kernel: /boot/config-6.19.13-400.asahi.fc44.aarch64+16k
[+] Detected cmdline parameters of the running kernel: /proc/cmdline
[+] Saved sysctls to a temporary file /tmp/sysctl-91xz5fm4
[+] Detected architecture: ARM64
[+] Detected compiler: GCC 160001
[!] WARNING: cmdline option "rootflags" is found multiple times
[-] ERROR: unexpected line in sysctl file: "net.ipv4.neigh.default.msysctl: permission denied on key 'net.ipv4.tcp_fastopen_key'"
[1]
$
```

After the commit, it just works.