### PR TITLE
Module loading checks

### DIFF
--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -968,10 +968,12 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
              # at first, it disabled unprivileged userfaultfd,
              # and since v5.11 it enables unprivileged userfaultfd for user-mode only
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modules_disabled', '1'),
+             CmdlineCheck('cut_attack_surface', 'kspp', 'nomodule', 'is present'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
                  have_kconfig))]
-             # kernel.modules_disabled=1 should be set (e.g. with systemd) after
-             # the kernel startup, when all the required modules have loaded
+             # block all module loading: kernel.modules_disabled=1 (set after the
+             # needed modules have loaded, e.g. with systemd) or the nomodule
+             # cmdline param; both use the same modules_disabled flag
 
     # 'cut_attack_surface', 'grsec'
     l += [OR(SysctlCheck('cut_attack_surface', 'grsec', 'kernel.io_uring_disabled', '2'),

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -974,6 +974,14 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
              # block all module loading: kernel.modules_disabled=1 (set after the
              # needed modules have loaded, e.g. with systemd) or the nomodule
              # cmdline param; both use the same modules_disabled flag
+    l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modprobe', 'is empty'),
+             SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modules_disabled', '1'),
+             CmdlineCheck('cut_attack_surface', 'kspp', 'nomodule', 'is present'),
+             AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
+                 have_kconfig))]
+             # disable module autoloading: an empty kernel.modprobe makes
+             # __request_module() bail out before the usermode helper; the
+             # stronger modules_disabled=1 / nomodule / MODULES=n disable it too
 
     # 'cut_attack_surface', 'grsec'
     l += [OR(SysctlCheck('cut_attack_surface', 'grsec', 'kernel.io_uring_disabled', '2'),

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -974,6 +974,15 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
              # block all module loading: kernel.modules_disabled=1 (set after the
              # needed modules have loaded, e.g. with systemd) or the nomodule
              # cmdline param; both use the same modules_disabled flag
+    l += [OR(SysctlCheck('cut_attack_surface', 'a13xp0p0v', 'kernel.modprobe', ''),
+             SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modules_disabled', '1'),
+             CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present'),
+             AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
+                 have_kconfig))]
+             # disable kernel-requested module autoloading: an empty kernel.modprobe
+             # makes __request_module() bail out before the usermode helper, but it
+             # doesn't prevent explicit modprobe/insmod; the stronger
+             # modules_disabled=1 / nomodule / MODULES=n disable all module loading
 
     # 'cut_attack_surface', 'grsec'
     l += [OR(SysctlCheck('cut_attack_surface', 'grsec', 'kernel.io_uring_disabled', '2'),

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -971,9 +971,11 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
              CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
                  have_kconfig))]
-             # block all module loading: kernel.modules_disabled=1 (set after the
-             # needed modules have loaded, e.g. with systemd) or the nomodule
-             # cmdline param; both use the same modules_disabled flag
+             # block loading kernel modules:
+             #  - set kernel.modules_disabled=1 (e.g. with systemd) after
+             #    the kernel startup, when the needed modules have been loaded
+             #  - or set the nomodule cmdline parameter (it uses the same
+             #    modules_disabled flag)
     l += [OR(SysctlCheck('cut_attack_surface', 'a13xp0p0v', 'kernel.modprobe', ''),
              SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modules_disabled', '1'),
              CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present'),

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -835,6 +835,7 @@ def add_cmdline_checks(l: list[ChecklistObjType], arch: str) -> None:
     l += [CmdlineCheck('cut_attack_surface', 'grapheneos', 'sysrq_always_enabled', 'is not set')]
 
     # 'cut_attack_surface', 'a13xp0p0v'
+    l += [CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present')]
     l += [OR(CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'bdev_allow_write_mounted', '0'),
              AND(KconfigCheck('cut_attack_surface', 'a13xp0p0v', 'BLK_DEV_WRITE_MOUNTED', 'is not set'),
                  CmdlineCheck('-', '-', 'bdev_allow_write_mounted', 'is not set')))]
@@ -967,10 +968,12 @@ def add_sysctl_checks(l: list[ChecklistObjType], arch: StrOrNone) -> None:
              # at first, it disabled unprivileged userfaultfd,
              # and since v5.11 it enables unprivileged userfaultfd for user-mode only
     l += [OR(SysctlCheck('cut_attack_surface', 'kspp', 'kernel.modules_disabled', '1'),
+             CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present'),
              AND(KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'),
                  have_kconfig))]
-             # kernel.modules_disabled=1 should be set (e.g. with systemd) after
-             # the kernel startup, when all the required modules have loaded
+             # block all module loading: kernel.modules_disabled=1 (set after the
+             # needed modules have loaded, e.g. with systemd) or the nomodule
+             # cmdline param; both use the same modules_disabled flag
 
     # 'cut_attack_surface', 'grsec'
     l += [OR(SysctlCheck('cut_attack_surface', 'grsec', 'kernel.io_uring_disabled', '2'),

--- a/kernel_hardening_checker/checks.py
+++ b/kernel_hardening_checker/checks.py
@@ -835,7 +835,8 @@ def add_cmdline_checks(l: list[ChecklistObjType], arch: str) -> None:
     l += [CmdlineCheck('cut_attack_surface', 'grapheneos', 'sysrq_always_enabled', 'is not set')]
 
     # 'cut_attack_surface', 'a13xp0p0v'
-    l += [CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present')]
+    l += [OR(CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'nomodule', 'is present'),
+             KconfigCheck('cut_attack_surface', 'kspp', 'MODULES', 'is not set'))]
     l += [OR(CmdlineCheck('cut_attack_surface', 'a13xp0p0v', 'bdev_allow_write_mounted', '0'),
              AND(KconfigCheck('cut_attack_surface', 'a13xp0p0v', 'BLK_DEV_WRITE_MOUNTED', 'is not set'),
                  CmdlineCheck('-', '-', 'bdev_allow_write_mounted', 'is not set')))]

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -61,7 +61,7 @@ class OptCheck:
                f'invalid expected value "{expected}" for "{name}" check (1)'
         val_len = len(expected.split())
         if val_len != 1:
-            assert (expected in {'is not set', 'is not off', 'is present'}), \
+            assert (expected in {'is not set', 'is not off', 'is present', 'is empty'}), \
                    f'invalid expected value "{expected}" for "{name}" check (2)'
         self.expected = expected
 
@@ -98,6 +98,16 @@ class OptCheck:
                 self.result = 'FAIL: is not present'
             else:
                 self.result = 'OK: is present'
+            return
+
+        # handle the 'is empty' check
+        if self.expected == 'is empty':
+            if self.state is None:
+                self.result = 'FAIL: is not found'
+            elif self.state == '':  # noqa: PLC1901
+                self.result = 'OK: is empty'
+            else:
+                self.result = f'FAIL: "{self.state}"'
             return
 
         # handle the 'is not off' option check
@@ -298,6 +308,8 @@ class OR(ComplexOptCheck):
                         self.result = f'OK: {opt.name} is not found'
                     elif opt.result == 'OK: is present':
                         self.result = f'OK: {opt.name} is present'
+                    elif opt.result == 'OK: is empty':
+                        self.result = f'OK: {opt.name} is empty'
                     else:
                         assert (opt.result.startswith('OK: is not off')), \
                                f'unexpected OK description "{opt.result}"'

--- a/kernel_hardening_checker/engine.py
+++ b/kernel_hardening_checker/engine.py
@@ -62,10 +62,10 @@ class OptCheck:
                f'invalid reason "{reason}" for "{name}" check'
         self.reason = reason
 
-        assert (expected and isinstance(expected, str) and expected == expected.strip()), \
+        assert (isinstance(expected, str) and expected == expected.strip()), \
                f'invalid expected value "{expected}" for "{name}" check (1)'
         val_len = len(expected.split())
-        if val_len != 1:
+        if val_len > 1:
             assert (expected in {'is not set', 'is not off', 'is present'}), \
                    f'invalid expected value "{expected}" for "{name}" check (2)'
         self.expected = expected

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -262,6 +262,9 @@ class TestEngine(unittest.TestCase):
         config_checklist += [SysctlCheck('reason_13', 'decision_13', 'name_13', '*expected_13*')]
         config_checklist += [SysctlCheck('reason_14', 'decision_14', 'name_14', '*expected_14*')]
         config_checklist += [SysctlCheck('reason_15', 'decision_15', 'name_15', '*expected_15*')]
+        config_checklist += [SysctlCheck('reason_16', 'decision_16', 'name_16', 'is empty')]
+        config_checklist += [SysctlCheck('reason_17', 'decision_17', 'name_17', 'is empty')]
+        config_checklist += [SysctlCheck('reason_18', 'decision_18', 'name_18', 'is empty')]
 
         # 2. prepare the parsed sysctl options
         parsed_sysctl_options = {}
@@ -275,6 +278,8 @@ class TestEngine(unittest.TestCase):
         parsed_sysctl_options['name_12'] = 'really_not_off,something'
         parsed_sysctl_options['name_13'] = '"expected_13,something,UNexpected2"'
         parsed_sysctl_options['name_14'] = 'UNexpected_14,something'
+        parsed_sysctl_options['name_16'] = ''
+        parsed_sysctl_options['name_17'] = 'not_empty'
 
         # 3. run the engine
         self.run_engine(config_checklist, None, None, parsed_sysctl_options, None)
@@ -298,7 +303,10 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_12', 'type': 'sysctl', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
                  {'option_name': 'name_13', 'type': 'sysctl', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
                  {'option_name': 'name_14', 'type': 'sysctl', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
-                 {'option_name': 'name_15', 'type': 'sysctl', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
+                 {'option_name': 'name_15', 'type': 'sysctl', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
+                 {'option_name': 'name_16', 'type': 'sysctl', 'reason': 'reason_16', 'decision': 'decision_16', 'desired_val': 'is empty', 'check_result': 'OK: is empty', 'check_result_bool': True},
+                 {'option_name': 'name_17', 'type': 'sysctl', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'is empty', 'check_result': 'FAIL: "not_empty"', 'check_result_bool': False},
+                 {'option_name': 'name_18', 'type': 'sysctl', 'reason': 'reason_18', 'decision': 'decision_18', 'desired_val': 'is empty', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
         )
 
     def test_complex_or(self) -> None:
@@ -320,6 +328,8 @@ class TestEngine(unittest.TestCase):
                                 KconfigCheck('reason_14', 'decision_14', 'NAME_14', '*expected_14*'))]
         config_checklist += [OR(KconfigCheck('reason_15', 'decision_15', 'NAME_15', 'expected_15'),
                                 KconfigCheck('reason_16', 'decision_16', 'NAME_16', '*expected_16*'))]
+        config_checklist += [OR(KconfigCheck('reason_17', 'decision_17', 'NAME_17', 'expected_17'),
+                                KconfigCheck('reason_18', 'decision_18', 'NAME_18', 'is empty'))]
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -335,6 +345,7 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_14'] = '"UNexpected_14,something,expected_14"'
         parsed_kconfig_options['CONFIG_NAME_15'] = 'UNexpected_15'
         parsed_kconfig_options['CONFIG_NAME_16'] = 'UNexpected_16,something,expected_16'
+        parsed_kconfig_options['CONFIG_NAME_18'] = ''
 
         # 3. run the engine
         self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
@@ -351,7 +362,8 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'OK: CONFIG_NAME_10 is present', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'OK: CONFIG_NAME_12 is not off', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'OK: "expected_14" is in CONFIG_NAME_14', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'OK: "expected_16" is in CONFIG_NAME_16', 'check_result_bool': True}],
+                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'OK: "expected_16" is in CONFIG_NAME_16', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'OK: CONFIG_NAME_18 is empty', 'check_result_bool': True}],
         )
 
     def test_complex_and(self) -> None:

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -328,6 +328,8 @@ class TestEngine(unittest.TestCase):
                                 KconfigCheck('reason_14', 'decision_14', 'NAME_14', '*expected_14*'))]
         config_checklist += [OR(KconfigCheck('reason_15', 'decision_15', 'NAME_15', 'expected_15'),
                                 KconfigCheck('reason_16', 'decision_16', 'NAME_16', '*expected_16*'))]
+        config_checklist += [OR(KconfigCheck('reason_17', 'decision_17', 'NAME_17', 'expected_17'),
+                                SysctlCheck('reason_18', 'decision_18', 'name_18', ''))]  # special check for empty value
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -344,10 +346,14 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_15'] = 'UNexpected_15'
         parsed_kconfig_options['CONFIG_NAME_16'] = 'UNexpected_16,something,expected_16'
 
-        # 3. run the engine
-        self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
+        # 3. prepare the parsed sysctl options
+        parsed_sysctl_options = {}
+        parsed_sysctl_options['name_18'] = ''
 
-        # 4. check that the results are correct
+        # 4. run the engine
+        self.run_engine(config_checklist, parsed_kconfig_options, None, parsed_sysctl_options, None)
+
+        # 5. check that the results are correct
         result = []  # type: ResultType
         self.get_engine_result(config_checklist, result, 'json')
         self.assertEqual(
@@ -359,7 +365,8 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_9', 'type': 'kconfig', 'reason': 'reason_9', 'decision': 'decision_9', 'desired_val': 'expected_9', 'check_result': 'OK: CONFIG_NAME_10 is present', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_11', 'type': 'kconfig', 'reason': 'reason_11', 'decision': 'decision_11', 'desired_val': 'expected_11', 'check_result': 'OK: CONFIG_NAME_12 is not off', 'check_result_bool': True},
                  {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'OK: "expected_14" is in CONFIG_NAME_14', 'check_result_bool': True},
-                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'OK: "expected_16" is in CONFIG_NAME_16', 'check_result_bool': True}],
+                 {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'OK: "expected_16" is in CONFIG_NAME_16', 'check_result_bool': True},
+                 {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'OK: name_18 is ""', 'check_result_bool': True}],
         )
 
     def test_complex_and(self) -> None:
@@ -385,6 +392,8 @@ class TestEngine(unittest.TestCase):
                                  KconfigCheck('reason_18', 'decision_18', 'NAME_18', '*expected_18*'))]
         config_checklist += [AND(KconfigCheck('reason_19', 'decision_19', 'NAME_19', 'expected_19'),
                                  KconfigCheck('reason_20', 'decision_20', 'NAME_20', '*expected_20*'))]
+        config_checklist += [AND(KconfigCheck('reason_21', 'decision_21', 'NAME_21', 'expected_21'),
+                                 SysctlCheck('reason_22', 'decision_22', 'name_22', ''))]  # special check for empty value
 
         # 2. prepare the parsed kconfig options
         parsed_kconfig_options = {}
@@ -406,6 +415,7 @@ class TestEngine(unittest.TestCase):
         parsed_kconfig_options['CONFIG_NAME_18'] = '"UNexpected_14,something"'
         parsed_kconfig_options['CONFIG_NAME_19'] = 'expected_15'
         parsed_kconfig_options['CONFIG_NAME_20'] = 'UNexpected_16,something'
+        parsed_kconfig_options['CONFIG_NAME_21'] = 'expected_21'
 
         # 3. run the engine
         self.run_engine(config_checklist, parsed_kconfig_options, None, None, None)
@@ -424,7 +434,8 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'CONFIG_NAME_13', 'type': 'kconfig', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': 'expected_13', 'check_result': 'FAIL: CONFIG_NAME_14 is off', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_15', 'type': 'kconfig', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': 'expected_15', 'check_result': 'FAIL: CONFIG_NAME_16 is off', 'check_result_bool': False},
                  {'option_name': 'CONFIG_NAME_17', 'type': 'kconfig', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': 'expected_17', 'check_result': 'FAIL: "expected_18" is not in CONFIG_NAME_18', 'check_result_bool': False},
-                 {'option_name': 'CONFIG_NAME_19', 'type': 'kconfig', 'reason': 'reason_19', 'decision': 'decision_19', 'desired_val': 'expected_19', 'check_result': 'FAIL: "expected_20" is not in CONFIG_NAME_20', 'check_result_bool': False}],
+                 {'option_name': 'CONFIG_NAME_19', 'type': 'kconfig', 'reason': 'reason_19', 'decision': 'decision_19', 'desired_val': 'expected_19', 'check_result': 'FAIL: "expected_20" is not in CONFIG_NAME_20', 'check_result_bool': False},
+                 {'option_name': 'CONFIG_NAME_21', 'type': 'kconfig', 'reason': 'reason_21', 'decision': 'decision_21', 'desired_val': 'expected_21', 'check_result': 'FAIL: name_22 is not ""', 'check_result_bool': False}],
         )
 
     def test_complex_nested(self) -> None:

--- a/kernel_hardening_checker/test_engine.py
+++ b/kernel_hardening_checker/test_engine.py
@@ -262,6 +262,9 @@ class TestEngine(unittest.TestCase):
         config_checklist += [SysctlCheck('reason_13', 'decision_13', 'name_13', '*expected_13*')]
         config_checklist += [SysctlCheck('reason_14', 'decision_14', 'name_14', '*expected_14*')]
         config_checklist += [SysctlCheck('reason_15', 'decision_15', 'name_15', '*expected_15*')]
+        config_checklist += [SysctlCheck('reason_16', 'decision_16', 'name_16', '')]
+        config_checklist += [SysctlCheck('reason_17', 'decision_17', 'name_17', '')]
+        config_checklist += [SysctlCheck('reason_18', 'decision_18', 'name_18', '')]
 
         # 2. prepare the parsed sysctl options
         parsed_sysctl_options = {}
@@ -275,6 +278,8 @@ class TestEngine(unittest.TestCase):
         parsed_sysctl_options['name_12'] = 'really_not_off,something'
         parsed_sysctl_options['name_13'] = '"expected_13,something,UNexpected2"'
         parsed_sysctl_options['name_14'] = 'UNexpected_14,something'
+        parsed_sysctl_options['name_16'] = ''
+        parsed_sysctl_options['name_17'] = 'not_empty'
 
         # 3. run the engine
         self.run_engine(config_checklist, None, None, parsed_sysctl_options, None)
@@ -298,7 +303,10 @@ class TestEngine(unittest.TestCase):
                  {'option_name': 'name_12', 'type': 'sysctl', 'reason': 'reason_12', 'decision': 'decision_12', 'desired_val': 'is not off', 'check_result': 'OK: is not off (really_not_off,something)', 'check_result_bool': True},
                  {'option_name': 'name_13', 'type': 'sysctl', 'reason': 'reason_13', 'decision': 'decision_13', 'desired_val': '*expected_13*', 'check_result': 'OK: in "expected_13,something,UNexpected2"', 'check_result_bool': True},
                  {'option_name': 'name_14', 'type': 'sysctl', 'reason': 'reason_14', 'decision': 'decision_14', 'desired_val': '*expected_14*', 'check_result': 'FAIL: not in UNexpected_14,something', 'check_result_bool': False},
-                 {'option_name': 'name_15', 'type': 'sysctl', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
+                 {'option_name': 'name_15', 'type': 'sysctl', 'reason': 'reason_15', 'decision': 'decision_15', 'desired_val': '*expected_15*', 'check_result': 'FAIL: is not found', 'check_result_bool': False},
+                 {'option_name': 'name_16', 'type': 'sysctl', 'reason': 'reason_16', 'decision': 'decision_16', 'desired_val': '', 'check_result': 'OK', 'check_result_bool': True},
+                 {'option_name': 'name_17', 'type': 'sysctl', 'reason': 'reason_17', 'decision': 'decision_17', 'desired_val': '', 'check_result': 'FAIL: "not_empty"', 'check_result_bool': False},
+                 {'option_name': 'name_18', 'type': 'sysctl', 'reason': 'reason_18', 'decision': 'decision_18', 'desired_val': '', 'check_result': 'FAIL: is not found', 'check_result_bool': False}],
         )
 
     def test_complex_or(self) -> None:


### PR DESCRIPTION
1. Complete `kernel.modules_disabled` and `!CONFIG_MODULE` checks with  `nomodule` cmdline argument.
2. Add weaker `kernel.modprobe` check that only restricts autoloading and can be reverted.

I decided to separate  `kernel.modprobe=''` from `kernel.modules_disabled` because it:
1. Only restricts modprobe (root user still can load modules with insmod)
2. Unlike `nomodule`, `!CONFIG_MODULE`  and  `kernel.modules_disabled` can be reverted at runtime.